### PR TITLE
Tuned the OpenShift files for performance.

### DIFF
--- a/ims-api/openshift/ims-api-bc.yaml
+++ b/ims-api/openshift/ims-api-bc.yaml
@@ -27,7 +27,6 @@ objects:
 
         CMD ["java", "-jar", "build/libs/ims-api.jar"]
       git:
-        ref: master
         uri: https://github.com/bcgov/ppr
       type: Git
     strategy:

--- a/ims-api/openshift/ims-api-dc.yaml
+++ b/ims-api/openshift/ims-api-dc.yaml
@@ -30,20 +30,15 @@ objects:
           deploymentconfig: ${API_NAME}
       spec:
         containers:
-        - env:
-          - name: PORT
-            value: "8080"
-          - name: WEB_CONCURRENCY
-            value: "4"
-          imagePullPolicy: Always
+        - imagePullPolicy: Always
           name: ${API_NAME}
           ports:
           - containerPort: 8080
             protocol: TCP
           resources:
             limits:
-              cpu: 50m
-              memory: 1024Mi
+              cpu: '1'
+              memory: 1Gi
             requests:
               cpu: 20m
               memory: 256Mi


### PR DESCRIPTION
Updated the buildconfig to:
 - Remove the `ref: master` as this prevents a shallow clone of the repo.

Updated the deployconfig to:
 - Removed two environment variables that were used by gunicorn/uvicorn.
 - Bumped the CPU limit to one core to speed up deployment time.
 - Changed the memory limit from 1024Mi to 1Gi, as OpenShift was seeing it as a change on "apply".