### PR TITLE
Add a health check endpoint

### DIFF
--- a/ims-api/build.gradle
+++ b/ims-api/build.gradle
@@ -13,6 +13,7 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.apache.commons:commons-lang3:3.9'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
     // TODO This project is found at http://rosemary.bcgov/svn/nro/trunk/jars/imsconnect. I explicitly built and
     // included as local jar for now, but we would be better served to pull the artifact from Artifactory.


### PR DESCRIPTION
Include the Spring Actuator, which adds a /actuator/health endpoint as well as other capabilities such as metrics and custom health checks.