### PR TITLE
Reformat lint

### DIFF
--- a/.github/workflows/compile-and-test-stage.yml
+++ b/.github/workflows/compile-and-test-stage.yml
@@ -50,7 +50,7 @@ jobs:
     - uses: actions/setup-node@v1
     - run: npm ci
       working-directory: ppr-ui
-    - run: npm run lint
+    - run: npm run lint -- --no-fix
       working-directory: ppr-ui
     - run: npm run test:unit
       working-directory: ppr-ui

--- a/ppr-ui/src/App.vue
+++ b/ppr-ui/src/App.vue
@@ -9,53 +9,53 @@
 </template>
 
 <script lang="ts">
-  import {computed, createComponent, onErrorCaptured, provide, ref} from "@vue/composition-api";
-  import {Data} from "@vue/composition-api/dist/component";
-  import {provideRouter, useRouter} from "@/router/router";
-  import FeatureOne from '@/components/FeatureOne.vue'
-  import FeatureTwo from '@/components/FeatureTwo.vue'
-  import AppData from "@/utils/app-data";
+import {computed, createComponent, onErrorCaptured, provide, ref} from "@vue/composition-api"
+import {Data} from "@vue/composition-api/dist/component"
+import {provideRouter, useRouter} from "@/router/router"
+import FeatureOne from '@/components/FeatureOne.vue'
+import FeatureTwo from '@/components/FeatureTwo.vue'
+import AppData from "@/utils/app-data"
 
-  const APP_PATH = process.env.VUE_APP_PATH || 'app-path-foo-bar'
-  const DefaultLayout = 'public'
+const APP_PATH = process.env.VUE_APP_PATH || 'app-path-foo-bar'
+const DefaultLayout = 'public'
 
-  function origin(): string {
-    const root = window.location.origin || ''
-    const path = APP_PATH
-    return `${root}/${path}`
+function origin(): string {
+  const root = window.location.origin || ''
+  const path = APP_PATH
+  return `${root}/${path}`
+}
+
+function authAPIURL(): string {
+  return sessionStorage.getItem('AUTH_API_URL')
+}
+
+export default createComponent({
+  components: { FeatureOne, FeatureTwo },
+  setup(): Data {
+    provideRouter()
+    const router = useRouter()
+
+    provide("originUrl", origin())
+    provide("authApiUrl", authAPIURL())
+    provide("featureOne", ref(AppData.features.featureOne))
+    provide("featureTwo", ref(AppData.features.featureTwo))
+    provide("configuration", ref(AppData.config))
+
+    const layout = computed((): string => (router.currentRoute.meta.layout || DefaultLayout) + '-layout')
+
+    onErrorCaptured((err): void => {
+      console.log('App errorCaptured', err)
+      // err: error trace
+      // The method has 2 additional parameters, which are unused in this case
+      //   vm: component in which error occured
+      //   info: Vue specific error information such as lifecycle hooks, events etc.
+      // TODO: Perform any custom logic or log to server
+      // return false to stop the propagation of errors further to parent or global error handler
+    })
+
+    return { layout }
   }
-
-  function authAPIURL(): string {
-    return sessionStorage.getItem('AUTH_API_URL')
-  }
-
-  export default createComponent({
-    components: { FeatureOne, FeatureTwo },
-    setup(): Data {
-      provideRouter()
-      const router = useRouter()
-
-      provide("originUrl", origin())
-      provide("authApiUrl", authAPIURL())
-      provide("featureOne", ref(AppData.features.featureOne))
-      provide("featureTwo", ref(AppData.features.featureTwo))
-      provide("configuration", ref(AppData.config))
-
-      const layout = computed((): string => (router.currentRoute.meta.layout || DefaultLayout) + '-layout')
-
-      onErrorCaptured((err): void => {
-        console.log('App errorCaptured', err)
-        // err: error trace
-        // The method has 2 additional parameters, which are unused in this case
-        //   vm: component in which error occured
-        //   info: Vue specific error information such as lifecycle hooks, events etc.
-        // TODO: Perform any custom logic or log to server
-        // return false to stop the propagation of errors further to parent or global error handler
-      })
-
-      return { layout }
-    }
-  })
+})
 
 </script>
 <style lang="scss">

--- a/ppr-ui/src/components/ConfigInfo.vue
+++ b/ppr-ui/src/components/ConfigInfo.vue
@@ -21,15 +21,15 @@
 </template>
 
 <script lang="ts">
-    import {createComponent, inject, reactive} from "@vue/composition-api";
-    import {Data} from "@vue/composition-api/dist/ts-api/component";
+import {createComponent, inject, reactive} from "@vue/composition-api"
+import {Data} from "@vue/composition-api/dist/ts-api/component"
 
-    export default createComponent({
-        setup(): Data {
-            const configuration = inject("configuration", reactive({}))
-            return {configuration}
-        }
-    })
+export default createComponent({
+  setup(): Data {
+    const configuration = inject("configuration", reactive({}))
+    return {configuration}
+  }
+})
 </script>
 <style lang="scss">
   dt {

--- a/ppr-ui/src/components/FeatureOne.vue
+++ b/ppr-ui/src/components/FeatureOne.vue
@@ -4,20 +4,20 @@
 </template>
 
 <script lang="ts">
-  import {computed, createComponent, inject, ref, watch} from "@vue/composition-api";
-  import {Data} from "@vue/composition-api/dist/component";
-  import AppData from '@/utils/app-data'
+import {computed, createComponent, inject, ref, watch} from "@vue/composition-api"
+import {Data} from "@vue/composition-api/dist/component"
+import AppData from '@/utils/app-data'
 
-  export default createComponent({
-    setup(): Data {
-      const featureOneFlag = inject("featureOne", ref(false))
-      const fOneToggleLabel = computed((): string => featureOneFlag.value ? 'Disable F One' : ' Enable F One')
+export default createComponent({
+  setup(): Data {
+    const featureOneFlag = inject("featureOne", ref(false))
+    const fOneToggleLabel = computed((): string => featureOneFlag.value ? 'Disable F One' : ' Enable F One')
 
-      watch(featureOneFlag, (flag): void => { AppData.features.featureOne = flag })
+    watch(featureOneFlag, (flag): void => { AppData.features.featureOne = flag })
 
-      return {featureOneFlag, fOneToggleLabel}
-    }
-  })
+    return {featureOneFlag, fOneToggleLabel}
+  }
+})
 </script>
 
 <style lang="scss">

--- a/ppr-ui/src/components/FeatureTwo.vue
+++ b/ppr-ui/src/components/FeatureTwo.vue
@@ -4,20 +4,20 @@
 </template>
 
 <script lang="ts">
-  import {computed, createComponent, inject, ref, watch} from "@vue/composition-api";
-  import {Data} from "@vue/composition-api/dist/component";
-  import AppData from '@/utils/app-data'
+import {computed, createComponent, inject, ref, watch} from "@vue/composition-api"
+import {Data} from "@vue/composition-api/dist/component"
+import AppData from '@/utils/app-data'
 
-  export default createComponent({
-    setup(): Data {
-      const featureTwoFlag = inject("featureTwo", ref(false))
-      const fOneToggleLabel = computed((): string => featureTwoFlag.value ? 'Disable F Two' : ' Enable F Two')
+export default createComponent({
+  setup(): Data {
+    const featureTwoFlag = inject("featureTwo", ref(false))
+    const fOneToggleLabel = computed((): string => featureTwoFlag.value ? 'Disable F Two' : ' Enable F Two')
 
-      watch(featureTwoFlag, (flag): void => { AppData.features.featureTwo = flag })
+    watch(featureTwoFlag, (flag): void => { AppData.features.featureTwo = flag })
 
-      return { featureTwoFlag, fOneToggleLabel }
-    }
-  })
+    return { featureTwoFlag, fOneToggleLabel }
+  }
+})
 </script>
 
 <style lang="scss">

--- a/ppr-ui/src/layouts/LayoutPublic.vue
+++ b/ppr-ui/src/layouts/LayoutPublic.vue
@@ -11,16 +11,16 @@
 </template>
 
 <script lang="ts">
-  import {createComponent} from "@vue/composition-api";
-  import SbcHeader from 'sbc-common-components/src/components/SbcHeader.vue'
-  import SbcFooter from 'sbc-common-components/src/components/SbcFooter.vue'
+import {createComponent} from "@vue/composition-api"
+import SbcHeader from 'sbc-common-components/src/components/SbcHeader.vue'
+import SbcFooter from 'sbc-common-components/src/components/SbcFooter.vue'
 
-  export default createComponent({
-    name: 'LayoutPublic',
-    components: {
-      SbcHeader,
-      SbcFooter,
-    },
-    inject: ['authApiUrl', 'originUrl']
-  })
+export default createComponent({
+  name: 'LayoutPublic',
+  components: {
+    SbcHeader,
+    SbcFooter,
+  },
+  inject: ['authApiUrl', 'originUrl']
+})
 </script>

--- a/ppr-ui/src/layouts/LayoutUser.vue
+++ b/ppr-ui/src/layouts/LayoutUser.vue
@@ -10,16 +10,16 @@
 </template>
 
 <script lang="ts">
-  import {createComponent} from "@vue/composition-api";
-  import SbcHeader from 'sbc-common-components/src/components/SbcHeader.vue'
-  import SbcFooter from 'sbc-common-components/src/components/SbcFooter.vue'
+import {createComponent} from "@vue/composition-api"
+import SbcHeader from 'sbc-common-components/src/components/SbcHeader.vue'
+import SbcFooter from 'sbc-common-components/src/components/SbcFooter.vue'
 
-  export default createComponent({
-    name: 'LayoutUser',
-    components: {
-      SbcHeader,
-      SbcFooter
-    },
-    inject: ['authApiUrl', 'originUrl'],
-  })
+export default createComponent({
+  name: 'LayoutUser',
+  components: {
+    SbcHeader,
+    SbcFooter
+  },
+  inject: ['authApiUrl', 'originUrl'],
+})
 </script>

--- a/ppr-ui/src/main.ts
+++ b/ppr-ui/src/main.ts
@@ -20,7 +20,7 @@ import layoutUser from '@/layouts/LayoutUser.vue'
 Import the global style sheet
  */
 import './assets/styles/styles.scss'
-import {Config} from "@/utils/app-data";
+import {Config} from "@/utils/app-data"
 
 const opts = {iconfont: 'mdi'}
 
@@ -37,7 +37,7 @@ Vue.config.errorHandler = (err, vm, info): void => {
   // info: Vue specific error information such as lifecycle hooks, events etc.
   // TODO: Perform any custom logic or log to server
   console.error('Vue main error handler', err, vm, info)
-};
+}
 
 configHelper.fetchConfig()
   .then((appConfig: Config): void => {
@@ -46,7 +46,7 @@ configHelper.fetchConfig()
         dsn: appConfig.sentryDSN,
         environment: appConfig.sentryEnvironment,
         integrations: [new Integrations.Vue({ Vue, attachProps: true })]
-      });
+      })
     }
     catch (err) {
       console.warn(`Sentry failed to initialize: ${err.message}`, err)

--- a/ppr-ui/src/router/router.ts
+++ b/ppr-ui/src/router/router.ts
@@ -1,14 +1,14 @@
 import Vue from 'vue'
 import VueRouter from 'vue-router'
-import {PositionResult} from "vue-router/types/router";
+import {PositionResult} from "vue-router/types/router"
 import routes from './routes'
 import authHelper from '@/utils/auth-helper'
-import {inject, provide} from "@vue/composition-api";
+import {inject, provide} from "@vue/composition-api"
 
 
 Vue.use(VueRouter)
 
-export const RouterSymbol = Symbol();
+export const RouterSymbol = Symbol()
 
 const router = new VueRouter({
   mode: 'history',
@@ -39,7 +39,7 @@ export function provideRouter() {
 export function useRouter(): VueRouter {
   const vueRouter: VueRouter = inject(RouterSymbol) as VueRouter
   if (!vueRouter) {
-    throw Error("Router cannot be injected, has not been provided");
+    throw Error("Router cannot be injected, has not been provided")
   }
   return vueRouter
 }

--- a/ppr-ui/src/shims-tsx.d.ts
+++ b/ppr-ui/src/shims-tsx.d.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-import Vue, {VNode} from "vue";
+import Vue, {VNode} from "vue"
 
 declare global {
   namespace JSX {

--- a/ppr-ui/src/utils/app-data.ts
+++ b/ppr-ui/src/utils/app-data.ts
@@ -37,7 +37,7 @@ export class Config {
 
   public constructor(data: object) {
     this.sentryDSN = data['SENTRY_DSN']
-    this.sentryEnvironment = data['SENTRY_ENVIRONMENT'];
+    this.sentryEnvironment = data['SENTRY_ENVIRONMENT']
   }
 
   public get authUrl(): string {

--- a/ppr-ui/src/utils/auth-helper.ts
+++ b/ppr-ui/src/utils/auth-helper.ts
@@ -1,5 +1,5 @@
-import axios from "@/utils/axios-auth";
-import AppData from '@/utils/app-data';
+import axios from "@/utils/axios-auth"
+import AppData from '@/utils/app-data'
 
 export default {
   authRedirect(): void {

--- a/ppr-ui/src/views/AuthStub.vue
+++ b/ppr-ui/src/views/AuthStub.vue
@@ -19,53 +19,53 @@
 </template>
 
 <script lang="ts">
-  import {computed, createComponent, ref} from "@vue/composition-api";
-  import {Data} from "@vue/composition-api/dist/ts-api/component";
-  import AuthHelper from '@/utils/auth-helper'
-  import {useRouter} from '@/router/router'
+import {computed, createComponent, ref} from "@vue/composition-api"
+import {Data} from "@vue/composition-api/dist/ts-api/component"
+import AuthHelper from '@/utils/auth-helper'
+import {useRouter} from '@/router/router'
 
-    export default createComponent({
-        setup(): Data {
-          const router = useRouter()
-            const errorMsg = ref<string>('')
-            const userName = ref<string>('')
-            const loggedInUser = ref<string>('')
+export default createComponent({
+  setup(): Data {
+    const router = useRouter()
+    const errorMsg = ref<string>('')
+    const userName = ref<string>('')
+    const loggedInUser = ref<string>('')
 
-            const hasSuccess = computed(() => loggedInUser.value.length > 0)
-            const hasError = computed(() => errorMsg.value.length > 0)
-            const saveDisabled = computed(() => userName.value.length === 0)
+    const hasSuccess = computed(() => loggedInUser.value.length > 0)
+    const hasError = computed(() => errorMsg.value.length > 0)
+    const saveDisabled = computed(() => userName.value.length === 0)
 
-            function letUserIn(): void {
-                errorMsg.value = ''
-                loggedInUser.value = ''
-                AuthHelper.authFake(userName.value)
-                    .then(() => {
-                        loggedInUser.value = userName.value
-                    })
-                    .catch(err => {
-                        console.log('authFake error', err)
-                        errorMsg.value = err.message
-                    })
-            }
-            function goToDash(): void {
-                router.push('dashboard')
-            }
+    function letUserIn(): void {
+      errorMsg.value = ''
+      loggedInUser.value = ''
+      AuthHelper.authFake(userName.value)
+        .then(() => {
+          loggedInUser.value = userName.value
+        })
+        .catch(err => {
+          console.log('authFake error', err)
+          errorMsg.value = err.message
+        })
+    }
+    function goToDash(): void {
+      router.push('dashboard')
+    }
 
-            function logOut(): void {
-                AuthHelper.authClear()
-                .then(() => {
-                  router.push('home')
-                })
-            }
+    function logOut(): void {
+      AuthHelper.authClear()
+        .then(() => {
+          router.push('home')
+        })
+    }
 
-            return {
-              errorMsg, hasError,
-              userName,  saveDisabled,
-              loggedInUser, hasSuccess,
-              letUserIn,
-              logOut,
-              goToDash
-          }
-        }
-    })
+    return {
+      errorMsg, hasError,
+      userName,  saveDisabled,
+      loggedInUser, hasSuccess,
+      letUserIn,
+      logOut,
+      goToDash
+    }
+  }
+})
 </script>

--- a/ppr-ui/src/views/Dashboard.vue
+++ b/ppr-ui/src/views/Dashboard.vue
@@ -27,27 +27,27 @@
 </template>
 
 <script lang="ts">
-  import {createComponent, inject, ref} from "@vue/composition-api";
-  import {Data} from "@vue/composition-api/dist/ts-api/component";
-  import AuthHelper from '@/utils/auth-helper'
-  import ConfigInfo from "@/components/ConfigInfo.vue"
-  import {useRouter} from '@/router/router'
+import {createComponent, inject, ref} from "@vue/composition-api"
+import {Data} from "@vue/composition-api/dist/ts-api/component"
+import AuthHelper from '@/utils/auth-helper'
+import ConfigInfo from "@/components/ConfigInfo.vue"
+import {useRouter} from '@/router/router'
 
-  export default createComponent({
-    components: {ConfigInfo},
-    setup(): Data {
-      const router = useRouter()
-      const featureOne = inject("featureOne", ref(false))
-      const featureTwo = inject("featureTwo", ref(false))
-      function logOut(): void {
-        AuthHelper.authClear()
+export default createComponent({
+  components: {ConfigInfo},
+  setup(): Data {
+    const router = useRouter()
+    const featureOne = inject("featureOne", ref(false))
+    const featureTwo = inject("featureTwo", ref(false))
+    function logOut(): void {
+      AuthHelper.authClear()
         .then(() => {
           router.push('home')
         })
-      }
-      return { featureOne, featureTwo, logOut }
     }
-  })
+    return { featureOne, featureTwo, logOut }
+  }
+})
 </script>
 
 <style lang="scss" scoped>

--- a/ppr-ui/src/views/Home.vue
+++ b/ppr-ui/src/views/Home.vue
@@ -24,21 +24,21 @@
 </template>
 
 <script lang="ts">
-  import {createComponent, inject, ref} from "@vue/composition-api";
-  import {Data} from "@vue/composition-api/dist/ts-api/component";
-  import {useRouter} from '@/router/router'
+import {createComponent, inject, ref} from "@vue/composition-api"
+import {Data} from "@vue/composition-api/dist/ts-api/component"
+import {useRouter} from '@/router/router'
 
-  export default createComponent({
-    setup(): Data {
-      const router = useRouter()
-      const featureOne = inject("featureOne", ref(false))
-      const featureTwo = inject("featureTwo", ref(false))
+export default createComponent({
+  setup(): Data {
+    const router = useRouter()
+    const featureOne = inject("featureOne", ref(false))
+    const featureTwo = inject("featureTwo", ref(false))
 
-      function login(): void {
-        router.push('auth')
-      }
-
-      return { featureOne, featureTwo, login }
+    function login(): void {
+      router.push('auth')
     }
-  })
+
+    return { featureOne, featureTwo, login }
+  }
+})
 </script>


### PR DESCRIPTION
I ran `npm run lint` to reformat according to our linting rules and committed the result.  I also changed the GitHub Action to use the `--no-fix` option to ensure the build fails on indent and semicolon errors, rather than reformatting and discarding silently.

You should review [PR #52] before this one.