### PR TITLE
Set up the OpenShift labels for bc and dc. #65

### DIFF
--- a/ims-api/openshift/ims-api-bc.yaml
+++ b/ims-api/openshift/ims-api-bc.yaml
@@ -6,7 +6,9 @@ objects:
   kind: BuildConfig
   metadata:
     labels:
+      app: ppr
       build: ${API_NAME}
+      role: ${API_NAME}
     name: ${API_NAME}
   spec:
     failedBuildsHistoryLimit: 5
@@ -30,14 +32,14 @@ objects:
         uri: https://github.com/bcgov/ppr
       type: Git
     strategy:
-      dockerStrategy:
-        noCache: false
+      dockerStrategy: {}
     successfulBuildsHistoryLimit: 5
 - apiVersion: image.openshift.io/v1
   kind: ImageStream
   metadata:
     labels:
-      app: ${API_NAME}
+      app: ppr
+      role: ${API_NAME}
     name: ${API_NAME}
   spec:
     lookupPolicy:

--- a/ims-api/openshift/ims-api-dc.yaml
+++ b/ims-api/openshift/ims-api-dc.yaml
@@ -133,6 +133,7 @@ parameters:
 - description: The name of the API.
   displayName: API Name
   name: API_NAME
+  required: true
   value: ims-api
 - description: The environment, such as "dev", "dev-pr13", "test", or "prod".
   displayName: Environment
@@ -142,8 +143,10 @@ parameters:
 - description: The image tag to build from.
   displayName: Image Tag
   name: IMAGE_TAG
+  required: true
   value: dev
 - description: The URL to use for the route.
   displayName: Route URL
   name: ROUTE_URL
+  required: true
   value: ims-api-dev.pathfinder.gov.bc.ca

--- a/ims-api/openshift/ims-api-dc.yaml
+++ b/ims-api/openshift/ims-api-dc.yaml
@@ -11,8 +11,10 @@ objects:
     replicas: 3
     revisionHistoryLimit: 10
     selector:
-      app: ${API_NAME}
+      app: ppr
       deploymentconfig: ${API_NAME}
+      environment: ${ENVIRONMENT}
+      role: ${API_NAME}
     strategy:
       activeDeadlineSeconds: 21600
       resources: {}
@@ -26,8 +28,10 @@ objects:
     template:
       metadata:
         labels:
-          app: ${API_NAME}
+          app: ppr
           deploymentconfig: ${API_NAME}
+          environment: ${ENVIRONMENT}
+          role: ${API_NAME}
       spec:
         containers:
         - envFrom:
@@ -91,7 +95,9 @@ objects:
   kind: Service
   metadata:
     labels:
-      app: ${API_NAME}
+      app: ppr
+      environment: ${ENVIRONMENT}
+      role: ${API_NAME}
     name: ${API_NAME}
   spec:
     ports:
@@ -107,7 +113,9 @@ objects:
   kind: Route
   metadata:
     labels:
-      app: ${API_NAME}
+      app: ppr
+      environment: ${ENVIRONMENT}
+      role: ${API_NAME}
     name: ${API_NAME}
   spec:
     host: ${ROUTE_URL}
@@ -125,15 +133,17 @@ parameters:
 - description: The name of the API.
   displayName: API Name
   name: API_NAME
-  required: true
   value: ims-api
+- description: The environment, such as "dev", "dev-pr13", "test", or "prod".
+  displayName: Environment
+  name: ENVIRONMENT
+  required: true
+  value: dev
 - description: The image tag to build from.
   displayName: Image Tag
   name: IMAGE_TAG
-  required: false
   value: dev
 - description: The URL to use for the route.
   displayName: Route URL
   name: ROUTE_URL
-  required: true
   value: ims-api-dev.pathfinder.gov.bc.ca


### PR DESCRIPTION
Updated the buildconfig and deployconfig to have labels than can be used in the networksecuritypolicy work.