### PR TITLE
Set up the OpenShift labels for bc and dc. #65

### DIFF
--- a/ims-api/openshift/ims-api-bc.yaml
+++ b/ims-api/openshift/ims-api-bc.yaml
@@ -1,6 +1,5 @@
 apiVersion: template.openshift.io/v1
 kind: Template
-metadata:
 objects:
 - apiVersion: v1
   kind: BuildConfig

--- a/ims-api/openshift/ims-api-dc.yaml
+++ b/ims-api/openshift/ims-api-dc.yaml
@@ -5,7 +5,9 @@ objects:
   kind: DeploymentConfig
   metadata:
     labels:
-      app: ${API_NAME}
+      app: ppr
+      deploymentconfig: ${API_NAME}
+      role: ${API_NAME}
     name: ${API_NAME}
   spec:
     replicas: 3


### PR DESCRIPTION
A couple of fixes for the previous PR:
 - the bc had an empty field, removed it for consistency with other bcs.
 - the dc was missing the label changes for the dc itself (again for consistency).