### PR TITLE
Support stubbing data in ims-api

### DIFF
--- a/ims-api/src/main/java/ca/bc/gov/registries/ppr/search/IMSSearchService.java
+++ b/ims-api/src/main/java/ca/bc/gov/registries/ppr/search/IMSSearchService.java
@@ -1,0 +1,33 @@
+package ca.bc.gov.registries.ppr.search;
+
+import ca.bc.gov.registries.imsconnect.IMSConnector;
+import ca.bc.gov.registries.ppr.imsconnect.IMSConnectorFactory;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+import static org.apache.commons.lang3.StringUtils.rightPad;
+
+@Component
+public class IMSSearchService implements ISearchService {
+    private static final String SERIAL_SEARCH_TX = "OLPPTSS";
+
+    private IMSConnectorFactory connectorFactory;
+
+    IMSSearchService(IMSConnectorFactory connectorFactory) {
+        this.connectorFactory = connectorFactory;
+    }
+
+    @Override
+    public List<String> findFinancialStatementsBySerial(String serial) throws Exception {
+        IMSConnector connector = connectorFactory.createConnection(SERIAL_SEARCH_TX);
+        try {
+            connector.connect();
+            // TODO this request is currently invalid.  Waiting on help to determine the correct contents of the request.
+            List<String> results = connector.makeRequest(rightPad(serial, 25));
+            return results;
+        } finally {
+            connector.disconnect();
+        }
+    }
+}

--- a/ims-api/src/main/java/ca/bc/gov/registries/ppr/search/ISearchService.java
+++ b/ims-api/src/main/java/ca/bc/gov/registries/ppr/search/ISearchService.java
@@ -1,0 +1,7 @@
+package ca.bc.gov.registries.ppr.search;
+
+import java.util.List;
+
+public interface ISearchService {
+    List<String> findFinancialStatementsBySerial(String serial) throws Exception;
+}

--- a/ims-api/src/main/java/ca/bc/gov/registries/ppr/search/StubSearchService.java
+++ b/ims-api/src/main/java/ca/bc/gov/registries/ppr/search/StubSearchService.java
@@ -1,0 +1,14 @@
+package ca.bc.gov.registries.ppr.search;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class StubSearchService implements ISearchService {
+    @Override
+    public List<String> findFinancialStatementsBySerial(String serial) {
+        return List.of("MV " + StringUtils.rightPad(serial, 25) + " 2010 MAZDA     ") ;
+    }
+}

--- a/ims-api/src/test/java/ca/bc/gov/registries/ppr/search/IMSSearchServiceTest.java
+++ b/ims-api/src/test/java/ca/bc/gov/registries/ppr/search/IMSSearchServiceTest.java
@@ -1,4 +1,4 @@
-package ca.bc.gov.registries.ppr;
+package ca.bc.gov.registries.ppr.search;
 
 import ca.bc.gov.registries.imsconnect.IMSConnector;
 import ca.bc.gov.registries.ppr.imsconnect.IMSConnectorFactory;
@@ -6,18 +6,15 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.List;
-import java.util.Map;
 
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
 import static org.apache.commons.lang3.StringUtils.rightPad;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
-public class SearchControllerTest {
-    private SearchController controller;
+public class IMSSearchServiceTest {
+    private IMSSearchService service;
 
     private IMSConnectorFactory mockConnectorFactory;
     private IMSConnector mockConnector;
@@ -28,44 +25,32 @@ public class SearchControllerTest {
         mockConnectorFactory = mock(IMSConnectorFactory.class);
         when(mockConnectorFactory.createConnection(anyString())).thenReturn(mockConnector);
 
-        controller = new SearchController(mockConnectorFactory);
+        service = new IMSSearchService(mockConnectorFactory);
     }
 
     @Test
-    public void searchSerial_ShouldPadInputTo25Characters() throws Exception {
+    public void findFinancialStatementsBySerial_ShouldPadInputTo25Characters() throws Exception {
         String serial = randomAlphanumeric(6);
         String expected = rightPad(serial, 25);
 
-        controller.searchBySerial(serial);
+        service.findFinancialStatementsBySerial(serial);
 
         verify(mockConnector).makeRequest(expected);
     }
 
     @Test
-    public void searchSerial_ResponseContainsSearchKeyAndIMSResults() throws Exception {
-        String serial = randomAlphanumeric(6);
-        when(mockConnector.makeRequest(anyString())).thenReturn(List.of("Hello", "World"));
-
-        Map<String, Object> expected = Map.of("serial", serial, "results", List.of("Hello", "World"));
-
-        Map<String, Object> response = controller.searchBySerial(serial);
-
-        assertEquals(expected, response);
-    }
-
-    @Test
-    public void searchSerial_CreatesConnectorWithSerialSearchTransaction() throws Exception {
-        controller.searchBySerial(null);
+    public void findFinancialStatementsBySerial_CreatesConnectorWithSerialSearchTransaction() throws Exception {
+        service.findFinancialStatementsBySerial(null);
 
         verify(mockConnectorFactory).createConnection("OLPPTSS");
     }
 
     @Test
-    public void searchSerial_ConnectorIsClosedWhenConnectFails() throws Exception {
+    public void findFinancialStatementsBySerial_ConnectorIsClosedWhenConnectFails() throws Exception {
         doThrow(IOException.class).when(mockConnector).connect();
 
         try {
-            controller.searchBySerial(randomAlphanumeric(6));
+            service.findFinancialStatementsBySerial(randomAlphanumeric(6));
             fail("An IOException was expected");
         } catch (IOException ex) {
             verify(mockConnector).disconnect();
@@ -73,14 +58,15 @@ public class SearchControllerTest {
     }
 
     @Test
-    public void searchSerial_ConnectorIsClosedWhenMakeRequestFails() throws Exception {
+    public void findFinancialStatementsBySerial_ConnectorIsClosedWhenMakeRequestFails() throws Exception {
         doThrow(IOException.class).when(mockConnector).makeRequest(anyString());
 
         try {
-            controller.searchBySerial(randomAlphanumeric(6));
+            service.findFinancialStatementsBySerial(randomAlphanumeric(6));
             fail("An IOException was expected");
         } catch (IOException ex) {
             verify(mockConnector).disconnect();
         }
     }
+
 }

--- a/ims-api/src/test/java/ca/bc/gov/registries/ppr/search/SearchControllerTest.java
+++ b/ims-api/src/test/java/ca/bc/gov/registries/ppr/search/SearchControllerTest.java
@@ -1,0 +1,46 @@
+package ca.bc.gov.registries.ppr.search;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+public class SearchControllerTest {
+    private SearchController controller;
+
+    private ISearchService mockSearchService;
+
+    @Before
+    public void setUp() {
+        mockSearchService = mock(ISearchService.class);
+
+        controller = new SearchController(mockSearchService);
+    }
+
+    @Test
+    public void searchSerial_ShouldProvideSerialToService() throws Exception {
+        String serial = randomAlphanumeric(6);
+
+        controller.searchBySerial(serial);
+
+        verify(mockSearchService).findFinancialStatementsBySerial(serial);
+    }
+
+    @Test
+    public void searchSerial_ResponseContainsSearchKeyAndIMSResults() throws Exception {
+        String serial = randomAlphanumeric(6);
+        when(mockSearchService.findFinancialStatementsBySerial(anyString())).thenReturn(List.of("Hello", "World"));
+
+        Map<String, Object> expected = Map.of("serial", serial, "results", List.of("Hello", "World"));
+
+        Map<String, Object> response = controller.searchBySerial(serial);
+
+        assertEquals(expected, response);
+    }
+}


### PR DESCRIPTION
Refactored the implementation to stub out search functionality without needing to interact with the IMS Server

My goal with this commit is to extract the IMS Connect portion of the application so we can begin stubbing out the API without being blocked by having the interactivity functioning.