### PR TITLE
Rework feature flag internals

### DIFF
--- a/ppr-ui/src/App.vue
+++ b/ppr-ui/src/App.vue
@@ -16,6 +16,7 @@
 import {computed, createComponent, onErrorCaptured, provide, ref} from "@vue/composition-api"
 import {Data} from "@vue/composition-api/dist/component"
 import {provideRouter, useRouter} from "@/router/router"
+import {FeatureFlags, provideFlags} from "@/flags/feature-flags"
 import FeatureOne from '@/components/FeatureOne.vue'
 import FeatureTwo from '@/components/FeatureTwo.vue'
 import AppData from "@/utils/app-data"
@@ -36,8 +37,12 @@ function authAPIURL(): string {
 export default createComponent({
   components: { FeatureOne, FeatureTwo },
   setup(): Data {
+    const devLDKey='key'
+    const fakeUserId = 'foobar'
+    const fflags = new FeatureFlags(devLDKey, fakeUserId)
     provideRouter()
     const router = useRouter()
+    provideFlags(fflags)
 
     provide("originUrl", origin())
     provide("authApiUrl", authAPIURL())

--- a/ppr-ui/src/components/FeatureOne.vue
+++ b/ppr-ui/src/components/FeatureOne.vue
@@ -1,31 +1,33 @@
 <template>
   <div class="features">
-    <v-checkbox class="f-check" id="featureOne" v-model="featureOneFlag" :label="fOneToggleLabel" />
+    <v-checkbox class="f-check" v-model="featureFlag" :label="featureLabel" />
   </div>
 </template>
 
 <script lang="ts">
-import {computed, createComponent, inject, ref, watch} from "@vue/composition-api"
+import {computed, createComponent, watch} from "@vue/composition-api"
 import {Data} from "@vue/composition-api/dist/component"
-import AppData from '@/utils/app-data'
+import {useFlags} from '@/flags/feature-flags'
 
 export default createComponent({
   setup(): Data {
-    const featureOneFlag = inject("featureOne", ref(false))
-    const fOneToggleLabel = computed((): string => featureOneFlag.value ? 'Disable F One' : ' Enable F One')
+    const name = 'One'
+    const flags = useFlags()
+    const featureFlag = flags.pocFeature1
+    const featureLabel = computed((): string => (featureFlag.value ? 'Disable' : ' Enable') + ' Feature ' + name)
 
-    watch(featureOneFlag, (flag): void => { AppData.features.featureOne = flag })
+    watch(featureFlag, (flag): void => { flags.pocFeature1.value = flag })
 
-    return {featureOneFlag, fOneToggleLabel}
+    return { name, featureFlag, featureLabel}
   }
 })
 </script>
 
-<style lang="scss">
+<style lang="scss" scoped>
 @import '@/assets/styles/theme.scss';
 
   .features {
-    margin-left: 2rem;
+    margin: 2rem;
     label {
       color: $gray3 !important;
       font-size: 16px;

--- a/ppr-ui/src/components/FeatureTwo.vue
+++ b/ppr-ui/src/components/FeatureTwo.vue
@@ -1,31 +1,33 @@
 <template>
   <div class="features">
-    <v-checkbox class="f-check" v-model="featureTwoFlag" :label="fOneToggleLabel" />
+    <v-checkbox class="f-check" v-model="featureFlag" :label="featureLabel" />
   </div>
 </template>
 
 <script lang="ts">
-import {computed, createComponent, inject, ref, watch} from "@vue/composition-api"
+import {computed, createComponent, watch} from "@vue/composition-api"
 import {Data} from "@vue/composition-api/dist/component"
-import AppData from '@/utils/app-data'
+import {useFlags} from '@/flags/feature-flags'
 
 export default createComponent({
   setup(): Data {
-    const featureTwoFlag = inject("featureTwo", ref(false))
-    const fOneToggleLabel = computed((): string => featureTwoFlag.value ? 'Disable F Two' : ' Enable F Two')
+    const name = 'Two'
+    const flags = useFlags()
+    const featureFlag = flags.pocFeature2
+    const featureLabel = computed((): string => (featureFlag.value ? 'Disable' : ' Enable') + ' Feature ' + name)
 
-    watch(featureTwoFlag, (flag): void => { AppData.features.featureTwo = flag })
+    watch(featureFlag, (flag): void => { flags.pocFeature2.value = flag })
 
-    return { featureTwoFlag, fOneToggleLabel }
+    return { name, featureFlag, featureLabel }
   }
 })
 </script>
 
-<style lang="scss">
+<style lang="scss" scoped>
 @import '@/assets/styles/theme.scss';
 
   .features {
-    margin-left: 2rem;
+    margin: 2rem;
     label {
       color: $gray3 !important;
       font-size: 16px;

--- a/ppr-ui/src/flags/feature-flags.ts
+++ b/ppr-ui/src/flags/feature-flags.ts
@@ -1,0 +1,32 @@
+import {ref, provide, inject, Ref} from "@vue/composition-api"
+
+// const ldKeys = ['poc-feature-1', 'poc-feature-2']
+
+export class FeatureFlags {
+  pocFeature1: Ref<boolean>
+  pocFeature2: Ref<boolean>
+  userKey: string
+
+  constructor(envKey: string, userKey: string) {
+    this.userKey = userKey
+    this.pocFeature1 = ref(false)
+    this.pocFeature2 = ref(false)
+  }
+}
+
+
+const FlagSymbol = Symbol()
+
+export function provideFlags(fflags) {
+  provide(FlagSymbol, fflags)
+}
+
+export function useFlags() {
+  const fflags: void | FeatureFlags = inject(FlagSymbol)
+  if (!fflags) {
+    throw new Error('No launch darkly flag class provided')
+  }
+  console.log('Feature Flags - useFlags', fflags)
+  return fflags
+}
+

--- a/ppr-ui/src/views/Home.vue
+++ b/ppr-ui/src/views/Home.vue
@@ -6,6 +6,14 @@
           <h1>PPR Sample Home Page</h1>
         </header>
 
+        <div>
+          <h4>Feature Flags</h4>
+          <ul>
+            <li>poc 1 {{featureOne}}</li>
+            <li>poc 2 {{featureTwo}}</li>
+          </ul>
+        </div>
+
         <div class="page-content">
           <div class="page-content__main">
             <section>
@@ -37,15 +45,17 @@
 </template>
 
 <script lang="ts">
-import {createComponent, inject, ref} from "@vue/composition-api"
+import {createComponent, Ref} from "@vue/composition-api"
 import {Data} from "@vue/composition-api/dist/ts-api/component"
 import {useRouter} from '@/router/router'
+import {useFlags} from '@/flags/feature-flags'
 
 export default createComponent({
   setup(): Data {
     const router = useRouter()
-    const featureOne = inject("featureOne", ref(false))
-    const featureTwo = inject("featureTwo", ref(false))
+    const flags = useFlags()
+    const featureOne: Ref = flags.pocFeature1
+    const featureTwo: Ref = flags.pocFeature2
 
     function login(): void {
       router.push('auth')


### PR DESCRIPTION
In preparation of using Launch Darkly refactor the way we manage and use feature flags in the code. Note these flags are reactive.
Next steps: remove the components that set feature flags and, instead, get the values from LD.