### PR TITLE
Run the lint formatting to cleanup warning on Vue templates.

### DIFF
--- a/ppr-ui/src/App.vue
+++ b/ppr-ui/src/App.vue
@@ -1,5 +1,8 @@
 <template>
-  <v-app class="app-container, theme--light" id="app">
+  <v-app
+    id="app"
+    class="app-container, theme--light"
+  >
     <component :is="layout">
       <router-view />
     </component>

--- a/ppr-ui/src/components/ConfigInfo.vue
+++ b/ppr-ui/src/components/ConfigInfo.vue
@@ -1,20 +1,25 @@
 <template>
   <div>
     <h2>Application Configuration Information</h2>
-    <dl><dt>PPR API URL</dt>
-      <dd>{{ configuration.pprApi}}
+    <dl>
+      <dt>PPR API URL</dt>
+      <dd>
+        {{ configuration.pprApi }}
         <div>Used to access the PPR API</div>
       </dd><dt>Authentication API  URL</dt>
-      <dd>{{configuration.authApiUrl}}
+      <dd>
+        {{ configuration.authApiUrl }}
         <div>Used to get authorizations and business information given a business ID and a valid JWT user token.</div>
         <div>Also provided to the SBC Common Header in the authURL property, along with the origin return URL</div>
       </dd><dt>Authentication URL</dt>
-      <dd>{{ configuration.authUrl}}
+      <dd>
+        {{ configuration.authUrl }}
         <div>Used on initial page load to redirect user to authenticate</div>
         <div>Used to redirect user to their business profile for let them do updates</div>
         <div>Used to redirect to make a payment</div>
       </dd><dt>Payment API URL</dt>
-      <dd>{{ configuration.payApiUrl}}
+      <dd>
+        {{ configuration.payApiUrl }}
         <div>Used to interact with the payment system</div>
       </dd>
     </dl>

--- a/ppr-ui/src/components/FeatureOne.vue
+++ b/ppr-ui/src/components/FeatureOne.vue
@@ -1,6 +1,11 @@
 <template>
   <div class="features">
-    <v-checkbox class="f-check" id="featureOne" v-model="featureOneFlag" :label="fOneToggleLabel" />
+    <v-checkbox
+      id="featureOne"
+      v-model="featureOneFlag"
+      class="f-check"
+      :label="fOneToggleLabel"
+    />
   </div>
 </template>
 

--- a/ppr-ui/src/components/FeatureTwo.vue
+++ b/ppr-ui/src/components/FeatureTwo.vue
@@ -1,6 +1,10 @@
 <template>
   <div class="features">
-    <v-checkbox class="f-check" v-model="featureTwoFlag" :label="fOneToggleLabel" />
+    <v-checkbox
+      v-model="featureTwoFlag"
+      class="f-check"
+      :label="fOneToggleLabel"
+    />
   </div>
 </template>
 

--- a/ppr-ui/src/layouts/LayoutPublic.vue
+++ b/ppr-ui/src/layouts/LayoutPublic.vue
@@ -1,6 +1,10 @@
 <template>
   <div>
-    <sbc-header ref="sbcHeader" :brandLink="originUrl" :authURL="authApiUrl" />
+    <sbc-header
+      ref="sbcHeader"
+      :brand-link="originUrl"
+      :auth-u-r-l="authApiUrl"
+    />
 
     <div class="app-body">
       <main>

--- a/ppr-ui/src/layouts/LayoutUser.vue
+++ b/ppr-ui/src/layouts/LayoutUser.vue
@@ -1,6 +1,10 @@
 <template>
   <div>
-    <sbc-header ref="sbcHeader" :brandLink="originUrl" :authURL="authApiUrl" />
+    <sbc-header
+      ref="sbcHeader"
+      :brand-link="originUrl"
+      :auth-u-r-l="authApiUrl"
+    />
 
     <div class="app-body">
       <main>

--- a/ppr-ui/src/views/AuthStub.vue
+++ b/ppr-ui/src/views/AuthStub.vue
@@ -6,21 +6,45 @@
           <h1>This is an authorization stub page</h1>
         </header>
       </article>
-      <div>userName {{userName}}</div>
+      <div>userName {{ userName }}</div>
       <v-card flat>
         <div v-if="hasSuccess">
-          <div>You've been signed in: {{userName}}</div>
-          <v-btn class="form-primary-btn" @click="goToDash" color="primary">Go to dashboard.</v-btn>
+          <div>You've been signed in: {{ userName }}</div>
+          <v-btn
+            class="form-primary-btn"
+            color="primary"
+            @click="goToDash"
+          >
+            Go to dashboard.
+          </v-btn>
         </div>
-        <div v-else class="intro">Try this button return do a 30-second login.
+        <div
+          v-else
+          class="intro"
+        >
+          Try this button return do a 30-second login.
           <v-form>
-            <v-text-field filled label="User Name" v-model="userName" required />
-            <v-btn class="form-primary-btn" @click="letUserIn" color="primary" v-bind:disabled="saveDisabled">Let me in!</v-btn>
+            <v-text-field
+              v-model="userName"
+              filled
+              label="User Name"
+              required
+            />
+            <v-btn
+              class="form-primary-btn"
+              color="primary"
+              :disabled="saveDisabled"
+              @click="letUserIn"
+            >
+              Let me in!
+            </v-btn>
           </v-form>
         </div>
       </v-card>
 
-      <div v-show="hasError">Error {{errorMsg}}</div>
+      <div v-show="hasError">
+        Error {{ errorMsg }}
+      </div>
     </v-container>
   </div>
 </template>

--- a/ppr-ui/src/views/Dashboard.vue
+++ b/ppr-ui/src/views/Dashboard.vue
@@ -27,7 +27,13 @@
     </v-container>
 
     <v-container>
-      <v-btn class="form-primary-btn" @click="logOut" color="primary">Let me out!</v-btn>
+      <v-btn
+        class="form-primary-btn"
+        color="primary"
+        @click="logOut"
+      >
+        Let me out!
+      </v-btn>
     </v-container>
   </div>
 </template>

--- a/ppr-ui/src/views/Home.vue
+++ b/ppr-ui/src/views/Home.vue
@@ -27,7 +27,13 @@
     </v-container>
 
     <v-container v-if="featureOne">
-      <v-btn class="form-primary-btn" @click="login" color="primary">Login</v-btn>
+      <v-btn
+        class="form-primary-btn"
+        color="primary"
+        @click="login"
+      >
+        Login
+      </v-btn>
     </v-container>
 
     <v-container v-if="featureTwo">


### PR DESCRIPTION
Last time we ran the lint with formatting the templates were all pug.  So running locally this time changed the templates, so it's mostly white space and attribute ordering changes.

This gets rid of about 65 warnings.