### PR TITLE
Refactor Feature Flags for Reactivity

### DIFF
--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -8,7 +8,8 @@
     "test": "npm run test:unit && npm run test:e2e",
     "test:unit": "vue-cli-service test:unit",
     "test:e2e": "vue-cli-service test:e2e",
-    "lint": "vue-cli-service lint"
+    "lint": "vue-cli-service lint",
+    "precommit": "vue-cli-service lint --no-fix && npm run build"
   },
   "dependencies": {
     "@sentry/browser": "^5.9.1",

--- a/ppr-ui/src/App.vue
+++ b/ppr-ui/src/App.vue
@@ -16,9 +16,10 @@
 </template>
 
 <script lang="ts">
-import {computed, createComponent, onErrorCaptured, provide, ref} from "@vue/composition-api"
+import {createComponent, computed, onErrorCaptured, provide, ref} from "@vue/composition-api"
 import {Data} from "@vue/composition-api/dist/component"
 import {provideRouter, useRouter} from "@/router/router"
+import {initializeFeatureFlags} from "@/flags/feature-flags"
 import FeatureOne from '@/components/FeatureOne.vue'
 import FeatureTwo from '@/components/FeatureTwo.vue'
 import AppData from "@/utils/app-data"
@@ -39,13 +40,14 @@ function authAPIURL(): string {
 export default createComponent({
   components: { FeatureOne, FeatureTwo },
   setup(): Data {
+
     provideRouter()
     const router = useRouter()
 
+    initializeFeatureFlags()
+
     provide("originUrl", origin())
     provide("authApiUrl", authAPIURL())
-    provide("featureOne", ref(AppData.features.featureOne))
-    provide("featureTwo", ref(AppData.features.featureTwo))
     provide("configuration", ref(AppData.config))
 
     const layout = computed((): string => (router.currentRoute.meta.layout || DefaultLayout) + '-layout')

--- a/ppr-ui/src/App.vue
+++ b/ppr-ui/src/App.vue
@@ -19,7 +19,7 @@
 import {createComponent, computed, onErrorCaptured, provide, ref} from "@vue/composition-api"
 import {Data} from "@vue/composition-api/dist/component"
 import {provideRouter, useRouter} from "@/router/router"
-import {initializeFeatureFlags} from "@/flags/feature-flags"
+import {provideFeatureFlags} from "@/flags/feature-flags"
 import FeatureOne from '@/components/FeatureOne.vue'
 import FeatureTwo from '@/components/FeatureTwo.vue'
 import AppData from "@/utils/app-data"
@@ -44,7 +44,7 @@ export default createComponent({
     provideRouter()
     const router = useRouter()
 
-    initializeFeatureFlags()
+    provideFeatureFlags()
 
     provide("originUrl", origin())
     provide("authApiUrl", authAPIURL())

--- a/ppr-ui/src/components/FeatureOne.vue
+++ b/ppr-ui/src/components/FeatureOne.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="features">
     <v-checkbox
+      id="featureOne"
       v-model="pocFeature1"
       class="f-check"
       :label="featureLabel"
@@ -9,19 +10,20 @@
 </template>
 
 <script lang="ts">
-import {computed, createComponent, watch} from "@vue/composition-api"
+import {computed, createComponent, ref, watch} from "@vue/composition-api"
 import {Data} from "@vue/composition-api/dist/component"
-import {useFeatureFlags, setPocFeature1} from '@/flags/feature-flags'
+import {useFeatureFlags} from '@/flags/feature-flags'
 
 export default createComponent({
   setup(): Data {
     const name = 'One'
-    const {pocFeature1} = useFeatureFlags()
+    const flags = useFeatureFlags()
+    const pocFeature1 = ref(flags.feature1)
 
-    const featureLabel = computed((): string => (pocFeature1.value ? 'Disable' : ' Enable') + ' Feature ' + name)
+    const featureLabel = computed((): string => (pocFeature1.value ? 'Disable' : ' Enable') + ' F ' + name)
 
     watch(pocFeature1, (flag): void => {
-      setPocFeature1(flag)
+      flags.feature1 = flag
     })
 
     return { name, pocFeature1, featureLabel}

--- a/ppr-ui/src/components/FeatureOne.vue
+++ b/ppr-ui/src/components/FeatureOne.vue
@@ -1,36 +1,39 @@
 <template>
   <div class="features">
     <v-checkbox
-      id="featureOne"
-      v-model="featureOneFlag"
+      v-model="pocFeature1"
       class="f-check"
-      :label="fOneToggleLabel"
+      :label="featureLabel"
     />
   </div>
 </template>
 
 <script lang="ts">
-import {computed, createComponent, inject, ref, watch} from "@vue/composition-api"
+import {computed, createComponent, watch} from "@vue/composition-api"
 import {Data} from "@vue/composition-api/dist/component"
-import AppData from '@/utils/app-data'
+import {useFeatureFlags, setPocFeature1} from '@/flags/feature-flags'
 
 export default createComponent({
   setup(): Data {
-    const featureOneFlag = inject("featureOne", ref(false))
-    const fOneToggleLabel = computed((): string => featureOneFlag.value ? 'Disable F One' : ' Enable F One')
+    const name = 'One'
+    const {pocFeature1} = useFeatureFlags()
 
-    watch(featureOneFlag, (flag): void => { AppData.features.featureOne = flag })
+    const featureLabel = computed((): string => (pocFeature1.value ? 'Disable' : ' Enable') + ' Feature ' + name)
 
-    return {featureOneFlag, fOneToggleLabel}
+    watch(pocFeature1, (flag): void => {
+      setPocFeature1(flag)
+    })
+
+    return { name, pocFeature1, featureLabel}
   }
 })
 </script>
 
-<style lang="scss">
+<style lang="scss" scoped>
 @import '@/assets/styles/theme.scss';
 
   .features {
-    margin-left: 2rem;
+    margin: 2rem;
     label {
       color: $gray3 !important;
       font-size: 16px;

--- a/ppr-ui/src/components/FeatureTwo.vue
+++ b/ppr-ui/src/components/FeatureTwo.vue
@@ -9,20 +9,20 @@
 </template>
 
 <script lang="ts">
-import {computed, createComponent, watch} from "@vue/composition-api"
+import {computed, createComponent, ref, watch} from "@vue/composition-api"
 import {Data} from "@vue/composition-api/dist/component"
-import {useFeatureFlags, setPocFeature2} from '@/flags/feature-flags'
+import {useFeatureFlags} from '@/flags/feature-flags'
 
 export default createComponent({
   setup(): Data {
     const name = 'Two'
-
-    const {pocFeature2} = useFeatureFlags()
+    const flags = useFeatureFlags()
+    const pocFeature2 = ref(flags.feature2)
 
     const featureLabel = computed((): string => (pocFeature2.value ? 'Disable' : ' Enable') + ' Feature ' + name)
 
     watch(pocFeature2, (flag): void => {
-      setPocFeature2(flag)
+      flags.feature2 = flag
     })
 
     return { name, pocFeature2, featureLabel}

--- a/ppr-ui/src/components/FeatureTwo.vue
+++ b/ppr-ui/src/components/FeatureTwo.vue
@@ -1,35 +1,40 @@
 <template>
   <div class="features">
     <v-checkbox
-      v-model="featureTwoFlag"
+      v-model="pocFeature2"
       class="f-check"
-      :label="fOneToggleLabel"
+      :label="featureLabel"
     />
   </div>
 </template>
 
 <script lang="ts">
-import {computed, createComponent, inject, ref, watch} from "@vue/composition-api"
+import {computed, createComponent, watch} from "@vue/composition-api"
 import {Data} from "@vue/composition-api/dist/component"
-import AppData from '@/utils/app-data'
+import {useFeatureFlags, setPocFeature2} from '@/flags/feature-flags'
 
 export default createComponent({
   setup(): Data {
-    const featureTwoFlag = inject("featureTwo", ref(false))
-    const fOneToggleLabel = computed((): string => featureTwoFlag.value ? 'Disable F Two' : ' Enable F Two')
+    const name = 'Two'
 
-    watch(featureTwoFlag, (flag): void => { AppData.features.featureTwo = flag })
+    const {pocFeature2} = useFeatureFlags()
 
-    return { featureTwoFlag, fOneToggleLabel }
+    const featureLabel = computed((): string => (pocFeature2.value ? 'Disable' : ' Enable') + ' Feature ' + name)
+
+    watch(pocFeature2, (flag): void => {
+      setPocFeature2(flag)
+    })
+
+    return { name, pocFeature2, featureLabel}
   }
 })
 </script>
 
-<style lang="scss">
-@import '@/assets/styles/theme.scss';
+<style lang="scss" scoped>
+  @import '@/assets/styles/theme.scss';
 
   .features {
-    margin-left: 2rem;
+    margin: 2rem;
     label {
       color: $gray3 !important;
       font-size: 16px;

--- a/ppr-ui/src/flags/feature-flags.ts
+++ b/ppr-ui/src/flags/feature-flags.ts
@@ -1,27 +1,41 @@
-import {toRefs, reactive} from "@vue/composition-api"
+import {inject, provide, reactive} from "@vue/composition-api"
 
-let _flags
+export class FeatureFlags {
+  private _feature1: boolean
+  private _feature2: boolean
 
-export function initializeFeatureFlags(): void {
-  _flags = reactive ( {
-    pocFeature1: false,
-    pocFeature2: false
-  })
+  public constructor(feature1: boolean = false, feature2: boolean = false) {
+    this._feature1 = feature1
+    this._feature2 = feature2
+  }
+
+  public get feature1(): boolean {
+    return this._feature1
+  }
+
+  public set feature1(feature1) {
+    this._feature1 = feature1
+  }
+
+  public get feature2(): boolean {
+    return this._feature2
+  }
+
+  public set feature2(feature2) {
+    this._feature2 = feature2
+  }
 }
 
-// Return object. Ideally the composition API would export the Refs<> type
-export function useFeatureFlags(): object {
-  return toRefs(_flags)
+export const FeatureFlagSymbol = Symbol()
+
+export function provideFeatureFlags(): void {
+  provide(FeatureFlagSymbol, reactive(new FeatureFlags()))
 }
 
-
-export function setPocFeature1 (value): void {
-  // console.log('set new value into feature flag', 'pocFeature1', value)
-  _flags.pocFeature1 = value
+export function useFeatureFlags(): FeatureFlags {
+  const featureFlags: FeatureFlags = inject(FeatureFlagSymbol) as FeatureFlags
+  if (!featureFlags) {
+    throw Error("FeatureFlags cannot be injected, has not been provided")
+  }
+  return featureFlags
 }
-
-export function setPocFeature2 (value): void {
-  // console.log('set new value into feature flag', 'pocFeature2', value)
-  _flags.pocFeature2 = value
-}
-

--- a/ppr-ui/src/flags/feature-flags.ts
+++ b/ppr-ui/src/flags/feature-flags.ts
@@ -1,0 +1,27 @@
+import {toRefs, reactive} from "@vue/composition-api"
+
+let _flags
+
+export function initializeFeatureFlags(): void {
+  _flags = reactive ( {
+    pocFeature1: false,
+    pocFeature2: false
+  })
+}
+
+// Return object. Ideally the composition API would export the Refs<> type
+export function useFeatureFlags(): object {
+  return toRefs(_flags)
+}
+
+
+export function setPocFeature1 (value): void {
+  // console.log('set new value into feature flag', 'pocFeature1', value)
+  _flags.pocFeature1 = value
+}
+
+export function setPocFeature2 (value): void {
+  // console.log('set new value into feature flag', 'pocFeature2', value)
+  _flags.pocFeature2 = value
+}
+

--- a/ppr-ui/src/utils/app-data.ts
+++ b/ppr-ui/src/utils/app-data.ts
@@ -1,26 +1,4 @@
 
-class FeatureFlags {
-  private _featureOne: boolean = false
-  public get featureOne(): boolean {
-    return this._featureOne
-  }
-
-  public set featureOne(flag: boolean) {
-    this._featureOne = flag
-  }
-
-  private _featureTwo: boolean = sessionStorage.getItem('FEATURE_TWO') === 'true'
-  public get featureTwo(): boolean {
-    return this._featureTwo
-  }
-
-  public set featureTwo(flag: boolean) {
-    // console.log('feature two set flag', flag)
-    sessionStorage.setItem('FEATURE_TWO', flag ? 'true' : 'false')
-    this._featureTwo = flag
-  }
-}
-
 /*
 Config
 Hides the implementation of storing configuration information.
@@ -99,11 +77,6 @@ class User {
 }
 
 class AppDataInternal {
-  private _features: FeatureFlags = new FeatureFlags()
-  public get features(): FeatureFlags {
-    return this._features
-  }
-
   private _config: Config = new Config({})
   public get config(): Config {
     return this._config

--- a/ppr-ui/src/views/Dashboard.vue
+++ b/ppr-ui/src/views/Dashboard.vue
@@ -12,7 +12,7 @@
               <header>
                 <h2>Sample content</h2>
               </header>
-              <v-container v-if="featureTwo">
+              <v-container v-if="flags.featureTwo">
                 <config-info />
               </v-container>
             </section>
@@ -55,10 +55,7 @@ export default createComponent({
     const router = useRouter()
 
     // Feature Flags
-    const {
-      pocFeature1: featureOne,
-      pocFeature2: featureTwo
-    } = useFeatureFlags()
+    const flags = useFeatureFlags()
 
     function logOut(): void {
       AuthHelper.authClear()
@@ -66,7 +63,7 @@ export default createComponent({
           router.push('home')
         })
     }
-    return { featureOne, featureTwo, logOut }
+    return { flags, logOut }
   }
 })
 </script>

--- a/ppr-ui/src/views/Dashboard.vue
+++ b/ppr-ui/src/views/Dashboard.vue
@@ -12,6 +12,9 @@
               <header>
                 <h2>Sample content</h2>
               </header>
+              <v-container v-if="featureTwo">
+                <config-info />
+              </v-container>
             </section>
           </div>
 
@@ -39,18 +42,24 @@
 </template>
 
 <script lang="ts">
-import {createComponent, inject, ref} from "@vue/composition-api"
+import {createComponent} from "@vue/composition-api"
 import {Data} from "@vue/composition-api/dist/ts-api/component"
 import AuthHelper from '@/utils/auth-helper'
 import ConfigInfo from "@/components/ConfigInfo.vue"
 import {useRouter} from '@/router/router'
+import {useFeatureFlags} from '@/flags/feature-flags'
 
 export default createComponent({
   components: {ConfigInfo},
   setup(): Data {
     const router = useRouter()
-    const featureOne = inject("featureOne", ref(false))
-    const featureTwo = inject("featureTwo", ref(false))
+
+    // Feature Flags
+    const {
+      pocFeature1: featureOne,
+      pocFeature2: featureTwo
+    } = useFeatureFlags()
+
     function logOut(): void {
       AuthHelper.authClear()
         .then(() => {

--- a/ppr-ui/src/views/Home.vue
+++ b/ppr-ui/src/views/Home.vue
@@ -34,7 +34,7 @@
       </article>
     </v-container>
 
-    <v-container v-if="featureOne">
+    <v-container v-if="flags.feature1">
       <v-btn
         class="form-primary-btn"
         color="primary"
@@ -57,15 +57,15 @@ export default createComponent({
     const router = useRouter()
 
     // Feature Flags
-    const {pocFeature1: featureOne, pocFeature2: featureTwo} = useFeatureFlags()
-    const featureOneLabel = computed((): string => (featureOne.value ? 'disabled' : ' enabled'))
-    const featureTwoLabel = computed((): string => (featureTwo.value ? 'disabled' : ' enabled'))
+    const flags = useFeatureFlags()
+    const featureOneLabel = computed((): string => (flags.feature1 ? 'enabled' : ' disabled'))
+    const featureTwoLabel = computed((): string => (flags.feature2 ? 'enabled' : 'disabled'))
 
     function login(): void {
       router.push('auth')
     }
 
-    return { featureOne, featureOneLabel, featureTwoLabel, login }
+    return { flags, featureOneLabel, featureTwoLabel, login }
   }
 })
 </script>

--- a/ppr-ui/src/views/Home.vue
+++ b/ppr-ui/src/views/Home.vue
@@ -6,6 +6,14 @@
           <h1>PPR Sample Home Page</h1>
         </header>
 
+        <div>
+          <h4>Feature Flags</h4>
+          <ul>
+            <li>poc 1 feature flags is {{ featureOneLabel }}</li>
+            <li>poc 2 feature flags is {{ featureTwoLabel }}</li>
+          </ul>
+        </div>
+
         <div class="page-content">
           <div class="page-content__main">
             <section>
@@ -35,29 +43,29 @@
         Login
       </v-btn>
     </v-container>
-
-    <v-container v-if="featureTwo">
-      <div>Feature two is active</div>
-    </v-container>
   </div>
 </template>
 
 <script lang="ts">
-import {createComponent, inject, ref} from "@vue/composition-api"
+import {createComponent, computed} from "@vue/composition-api"
 import {Data} from "@vue/composition-api/dist/ts-api/component"
 import {useRouter} from '@/router/router'
+import {useFeatureFlags} from '@/flags/feature-flags'
 
 export default createComponent({
   setup(): Data {
     const router = useRouter()
-    const featureOne = inject("featureOne", ref(false))
-    const featureTwo = inject("featureTwo", ref(false))
+
+    // Feature Flags
+    const {pocFeature1: featureOne, pocFeature2: featureTwo} = useFeatureFlags()
+    const featureOneLabel = computed((): string => (featureOne.value ? 'disabled' : ' enabled'))
+    const featureTwoLabel = computed((): string => (featureTwo.value ? 'disabled' : ' enabled'))
 
     function login(): void {
       router.push('auth')
     }
 
-    return { featureOne, featureTwo, login }
+    return { featureOne, featureOneLabel, featureTwoLabel, login }
   }
 })
 </script>

--- a/ppr-ui/tests/unit/example.spec.ts
+++ b/ppr-ui/tests/unit/example.spec.ts
@@ -5,12 +5,11 @@ import Vue from 'vue'
 import Vuetify from 'vuetify'
 import VueCompositionApi from '@vue/composition-api'
 // Utilities
-import {mount, createLocalVue} from '@vue/test-utils'
-
+import {createLocalVue, mount} from '@vue/test-utils'
 // Components
 import FeatureOne from '@/components/FeatureOne.vue'
 // Application
-import AppData from '@/utils/app-data'
+import {FeatureFlags, FeatureFlagSymbol} from "@/flags/feature-flags"
 
 Vue.use(Vuetify)
 Vue.use(VueCompositionApi)
@@ -18,22 +17,24 @@ const localVue = createLocalVue()
 
 describe('FeatureOne.vue', (): void => {
   let vuetify, wrapper
+  const featureFlags = new FeatureFlags()
 
   beforeEach((): void => {
     vuetify = new Vuetify()
     wrapper = mount(FeatureOne, {
       localVue,
       vuetify,
+      provide: {[FeatureFlagSymbol]: featureFlags}
     })
 
   })
 
-  it('Test app data features', (): void => {
-    expect(AppData.features.featureOne).toBeFalsy()
-    AppData.features.featureOne = true
-    expect(AppData.features.featureOne).toBeTruthy()
-    AppData.features.featureOne = false
-    expect(AppData.features.featureOne).toBeFalsy()
+  it('Test flagging feature one', (): void => {
+    expect(featureFlags.feature1).toBeFalsy()
+    featureFlags.feature1 = true
+    expect(featureFlags.feature1).toBeTruthy()
+    featureFlags.feature1 = false
+    expect(featureFlags.feature1).toBeFalsy()
   })
 
   it('should have a custom label and match snapshot', (): void => {
@@ -49,6 +50,6 @@ describe('FeatureOne.vue', (): void => {
   it('check should enable feature one', (): void => {
     const checkbox = wrapper.find('#featureOne')
     checkbox.trigger('click')
-    expect(AppData.features.featureOne).toBeTruthy()
+    expect(featureFlags).toBeTruthy()
   })
 })


### PR DESCRIPTION
Combined work with Bryan to begin the process of integrating Launch Darkly.  This step refactors our existing placeholder FF approach to leverage reactivity.  By providing the "global" ff object in the App using `reactive()`, when we inject the object into components and leverage it in templates, the UI will respond immediately to changes in settings.

The following step after this commit will be to replace the internals with Launch Darkly integration. 