### PR TITLE
Handle empty years in IMS API

### DIFF
--- a/ims-api/src/main/java/ca/bc/gov/registries/ppr/imsconnect/message/AbstractMessage.java
+++ b/ims-api/src/main/java/ca/bc/gov/registries/ppr/imsconnect/message/AbstractMessage.java
@@ -9,6 +9,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 
 import static ca.bc.gov.registries.ppr.imsconnect.message.ByteArrayUtils.*;
+import static org.apache.commons.lang3.StringUtils.isBlank;
 
 public abstract class AbstractMessage implements Record, RecordBytes, Streamable {
     protected static final int LL_INDEX = 0;
@@ -44,8 +45,12 @@ public abstract class AbstractMessage implements Record, RecordBytes, Streamable
         return readShortFromBuffer(buffer, offset);
     }
 
-    protected int readStringAsInteger(int offset, int length) {
-        return Integer.parseInt(readString(offset, length));
+    protected Integer readStringAsInteger(int offset, int length) {
+        String intString = readString(offset, length);
+        if (isBlank(intString)) {
+            return null;
+        }
+        return Integer.parseInt(intString);
     }
 
     @Override

--- a/ims-api/src/main/java/ca/bc/gov/registries/ppr/search/VehicleSummarySearchResult.java
+++ b/ims-api/src/main/java/ca/bc/gov/registries/ppr/search/VehicleSummarySearchResult.java
@@ -4,10 +4,10 @@ public class VehicleSummarySearchResult {
     private boolean exactMatch;
     private String type;
     private String vin;
-    private int year;
+    private Integer year;
     private String make;
 
-    public VehicleSummarySearchResult(boolean exactMatch, String type, String vin, int year, String make) {
+    public VehicleSummarySearchResult(boolean exactMatch, String type, String vin, Integer year, String make) {
         this.exactMatch = exactMatch;
         this.type = type;
         this.vin = vin;
@@ -27,7 +27,7 @@ public class VehicleSummarySearchResult {
         return vin;
     }
 
-    public int getYear() {
+    public Integer getYear() {
         return year;
     }
 

--- a/ims-api/src/test/java/ca/bc/gov/registries/ppr/imsconnect/message/SearchOutputMessageTest.java
+++ b/ims-api/src/test/java/ca/bc/gov/registries/ppr/imsconnect/message/SearchOutputMessageTest.java
@@ -122,8 +122,17 @@ public class SearchOutputMessageTest {
         SearchOutputMessage message = getSampleMessage();
 
         List<VehicleSummarySearchResult> vehicles = message.getVehicles();
-        assertEquals(1989, vehicles.get(0).getYear());
-        assertEquals(2005, vehicles.get(1).getYear());
+        assertEquals(Integer.valueOf(1989), vehicles.get(0).getYear());
+        assertEquals(Integer.valueOf(2005), vehicles.get(1).getYear());
+    }
+
+    @Test
+    public void testGetVehicle_YearShouldBeNullWhenValueIsEmpty() throws Exception {
+        SearchOutputMessage message = getSampleMessage();
+        overwriteBytes(message, 416, "    ".getBytes(EBCDIC_CHAR_SET));
+
+        List<VehicleSummarySearchResult> vehicles = message.getVehicles();
+        assertNull(vehicles.get(0).getYear());
     }
 
     @Test


### PR DESCRIPTION
PPR allows users to input collateral without specifying a year.  In this case, return a null year in the API.

JIRA: PPR-90