### PR TITLE
Include flake8 when performing linting during the build

### DIFF
--- a/.github/workflows/compile-and-test-stage.yml
+++ b/.github/workflows/compile-and-test-stage.yml
@@ -18,10 +18,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements/dev.txt
-      - name: Lint with PyLint
+      - name: Lint non-test Source
         working-directory: ppr-api
         run: |
           pylint -E src
+          flake8 src
       - name: Execute Unit Tests with PyTest
         working-directory: ppr-api
         run: |


### PR DESCRIPTION
Since @WalterMoar added `flake8` to the project, augment the build process to leverage it, in addition to `pylint`.