### PR TITLE
Bumped pod cpu limits to allow startup. #80

### DIFF
--- a/ppr-api/README.md
+++ b/ppr-api/README.md
@@ -10,9 +10,20 @@ The PPR API is currently a passthrough API that calls the IMS Transaction Manage
 
 ## Application Configuration
 
+### OpenShift Configuration
+
+Note that if the pods are not starting, and producing errors like:
+
+> [CRITICAL] WORKER TIMEOUT (pid:10)
+
+it can be that there's isn't enough CPU to start the uvicorn processes within gunicorn's 30 second timeout. Try giving
+the pods a little more CPU.
+
 ### Uvicorn/Gunicon Configuration
 
 These settings configure the [Uvicorn/Gunicon](https://github.com/tiangolo/uvicorn-gunicorn-fastapi-docker) web server.
+Although the server is tuned down to 4 processes to lighten the resource usage, with three pods it still has a dozen
+worker processes running.
 
 | Environment Variable | Description             |
 | -------------------- | ----------------------- |

--- a/ppr-api/README.md
+++ b/ppr-api/README.md
@@ -16,8 +16,8 @@ Note that if the pods are not starting, and producing errors like:
 
 > [CRITICAL] WORKER TIMEOUT (pid:10)
 
-it can be that there's isn't enough CPU to start the uvicorn processes within gunicorn's 30 second timeout. Try giving
-the pods a little more CPU.
+it can be that there isn't enough CPU to start the uvicorn processes within gunicorn's 30 second timeout. Try giving the
+pods a little more CPU.
 
 ### Uvicorn/Gunicon Configuration
 

--- a/ppr-api/openshift/ppr-api-dc.yaml
+++ b/ppr-api/openshift/ppr-api-dc.yaml
@@ -67,7 +67,7 @@ objects:
             timeoutSeconds: 10
           resources:
             limits:
-              cpu: 50m
+              cpu: 100m
               memory: 250Mi
             requests:
               cpu: 10m


### PR DESCRIPTION
The pods were failing to start. The CPU limit was so conservative that the additional endpoints were enough for the uvicorn worker processes to not start up within uvicorn's 30 second timeout. Uvicorn was killing the workers and restarting them, and then repeating the process. As the health checks were not in place yet, the deployment rolled out the pods that were not started.