### PR TITLE
Configure liveness probe delay. #86

### DIFF
--- a/ppr-api/openshift/ppr-api-dc.yaml
+++ b/ppr-api/openshift/ppr-api-dc.yaml
@@ -48,6 +48,7 @@ objects:
               path: /health
               port: 8080
               scheme: HTTP
+            initialDelaySeconds: 20
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1
@@ -67,7 +68,7 @@ objects:
             timeoutSeconds: 10
           resources:
             limits:
-              cpu: 100m
+              cpu: 500m
               memory: 250Mi
             requests:
               cpu: 10m


### PR DESCRIPTION
Reconfigured the liveness probe as it was killing the pods when they took too long to start up.

Also bumped up the CPU as the uvicorn workers were taking 20-25s to start, which is a little too close to the 30 timeout that gunicorn enforces.