### PR TITLE
Add a health check 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,18 @@
 version: "3.1"
 
 services:
+  ####################### PPR Database Definition #######################
+  ppr_db:
+    image: postgres:11
+    restart: always
+    environment:
+      POSTGRES_DB: ppr
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+    ports:
+      - "5432:5432"
+    volumes:
+      - ppr_db_data
+
   #################### Jaeger Tracing Service Definition ####################
   jaeger:
     image: jaegertracing/all-in-one
@@ -10,3 +22,6 @@ services:
       - "5775:5775/udp"
       - "6831:6831/udp"
       - "6832:6832/udp"
+
+volumes:
+  ppr_db_data:

--- a/docs/ppr-api/development.md
+++ b/docs/ppr-api/development.md
@@ -30,6 +30,17 @@ source ./.venv/bin/activate
 
 This will install what is needed to run in VS Code. Note that there will be errors regarding an invalid command 'bdist_wheel', but these don't appear to be a problem.
 
+## Start a local PostgreSQL database
+
+The web service is dependent on a postgres database which can be launched with docker compose.  You **must** specify a
+password for the database using the `DB_PASSWORD` environment variable.  This is required by both docker compose
+and the service.
+
+In the root project directory, run:
+```
+$ docker-compose up -d
+```
+
 ## Start the Web Service
 
 ```
@@ -37,6 +48,9 @@ This will install what is needed to run in VS Code. Note that there will be erro
 ```
 
 This should bring the web service up on http://localhost:8000, with OpenAPI documentation available at http://localhost:8000/docs.
+
+**Note:** The webservice requires the `DB_PASSWORD` environment variable, which should be the same as the one
+provided when you ran *docker-compose*.
 
 ### Using a debugger
 

--- a/ppr-api/README.md
+++ b/ppr-api/README.md
@@ -8,6 +8,18 @@ The PPR API is currently a passthrough API that calls the IMS Transaction Manage
 1. `$ (cd src && uvicorn main:app --reload)`
 1. View the [OpenAPI Docs](http://127.0.0.1:8000/docs).
 
+### Local Dependencies
+
+The api requires a **PostgreSQL** database which can be launched locally with docker compose. You must specify a password for
+the database using the `DB_PASSWORD` environment variable. This is required by both docker compose PPR API.
+
+Docker compose will also bring up an instance of Jaeger.
+
+From the project root folder:
+```
+$ docker-compose up -d
+```
+
 ## Application Configuration
 
 ### OpenShift Configuration
@@ -29,6 +41,18 @@ worker processes running.
 | -------------------- | ----------------------- |
 | PORT                 | Port to listen on: 8080 |
 | WEB_CONCURRENCY      | Number of processes: 4  |
+
+### PostgreSQL Database Configuration
+
+These settings are for building connections to the database.
+
+| Environment Variable | Description                                   |
+| -------------------- | --------------------------------------------- |
+| DB_HOSTNAME          | Host where the database is located: localhost |
+| DB_PORT              | Port to listen on: 5432                       |
+| DB_NAME              | The name of the database: ppr                 |
+| DB_USERNAME          | The username to connect with: postgres        |
+| DB_PASSWORD          | The password of the user. **Required**        |
 
 ### Sentry Configuration
 

--- a/ppr-api/requirements.txt
+++ b/ppr-api/requirements.txt
@@ -1,3 +1,5 @@
 
 email-validator==1.0.5 # Uvicorn complains without this.
+psycopg2-binary==2.8.4
 requests==2.22.0
+sqlalchemy==1.3.10

--- a/ppr-api/src/endpoints/healthcheck.py
+++ b/ppr-api/src/endpoints/healthcheck.py
@@ -1,8 +1,33 @@
+import logging
+
 import fastapi
+import sqlalchemy.orm
+
+import models.database
 
 router = fastapi.APIRouter()
+logger = logging.getLogger(__name__)
+
+STATUS_UP = "UP"
+STATUS_DOWN = "DOWN"
 
 
 @router.get("/health")
-async def health():
-    return {"status": "UP"}
+def health(session: sqlalchemy.orm.Session = fastapi.Depends(models.database.get_session)):
+    """
+    Returns a health check for this service and external resources. Downstream resources do not affect the overall
+    status.
+    """
+    return {
+        "status": STATUS_UP,
+        "database": database_status(session)
+    }
+
+
+def database_status(session: sqlalchemy.orm.Session):
+    try:
+        session.execute('SELECT 1')
+        return STATUS_UP
+    except Exception:
+        logger.warning("Database healthcheck failed", exc_info=True)
+        return STATUS_DOWN

--- a/ppr-api/src/models/database.py
+++ b/ppr-api/src/models/database.py
@@ -1,0 +1,31 @@
+import os
+
+import sqlalchemy
+import sqlalchemy.orm
+
+DB_PASSWORD = os.getenv('DB_PASSWORD')
+if not DB_PASSWORD:
+    raise Exception('DB_PASSWORD environment variable is required')
+
+DATABASE_URI = 'postgresql://{user}:{password}@{host}:{port}/{name}'.format(
+    user=os.getenv('DB_USERNAME', 'postgres'),
+    password=DB_PASSWORD,
+    host=os.getenv('DB_HOSTNAME', 'localhost'),
+    port=int(os.getenv('DB_PORT', '5432')),
+    name=os.getenv('DB_NAME', 'ppr')
+)
+
+engine = sqlalchemy.create_engine(DATABASE_URI)
+SessionLocal = sqlalchemy.orm.sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+def get_session():
+    """
+    Returns a session using yield to facilitate using it as a dependency in FastAPI.  See
+    https://fastapi.tiangolo.com/tutorial/dependencies/dependencies-with-yield/
+    """
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/ppr-api/tests/unit/conftest.py
+++ b/ppr-api/tests/unit/conftest.py
@@ -1,0 +1,6 @@
+import os
+
+
+def pytest_configure(config):
+    os.environ["DB_PASSWORD"] = "test_password"
+    return config

--- a/ppr-api/tests/unit/endpoints/test_healthcheck.py
+++ b/ppr-api/tests/unit/endpoints/test_healthcheck.py
@@ -1,0 +1,23 @@
+import endpoints.healthcheck
+
+
+def test_database_status_without_exception():
+    expected = "UP"
+    actual = endpoints.healthcheck.database_status(MockSession())
+    assert expected == actual
+
+
+def test_database_status_throws_exception():
+    expected = "DOWN"
+    actual = endpoints.healthcheck.database_status(MockSession(True))
+    assert expected == actual
+
+
+class MockSession:
+    def __init__(self, should_fail=False):
+        self.should_fail = should_fail
+
+    def execute(self, sql):
+        if self.should_fail:
+            raise Exception('execute failed intentionally')
+        return None


### PR DESCRIPTION
There's a couple of things going on here, as there were a few dependencies needed to get this working.  I'm open to suggestions on better ways to handle some of the code, as this is my first attempt at dealing with mocking out dependencies in unit tests.  I tried to follow what I saw as pre-existing patterns, but it would be good if we could take a more OO or functional approach to the database setup to prevent some of the application from executing on import.

@WalterMoar There's another bit of chicken and egg issue here.  Even if the database isn't available, this will require an environment variable for the database password on startup, so we'll need to take care in the deployment process and setup the db config in OpenShift before we deploy.  Even if the database doesn't exist, the application should be fine.  We just need specify the env variables.

I'm also assuming we'll need to reorganize this a bit once your current work is complete.