### PR TITLE
Read ims api service from environment. #91

### DIFF
--- a/ppr-api/README.md
+++ b/ppr-api/README.md
@@ -4,6 +4,7 @@ The PPR API is currently a passthrough API that calls the IMS Transaction Manage
 
 ## Developer Setup
 
+1. Copy the dotenv [environment file](../docs/.env) to somewhere above the source code.
 1. `$ pip install -r requirements/dev.txt`
 1. `$ (cd src && uvicorn main:app --reload)`
 1. View the [OpenAPI Docs](http://127.0.0.1:8000/docs).

--- a/ppr-api/docs/.env
+++ b/ppr-api/docs/.env
@@ -1,0 +1,14 @@
+#
+# This file contains the environment-specific settings that are read by python-dotenv. Place it somewhere above your
+# source code and it will be used. To prevent clashes, please use application-specific variable name prefixes.
+#
+
+# =====  ppr-api ======================================================================================================
+
+# The IMS API is not exposed from the cluster using a route, so it needs to be port forwarded:
+#
+#     $ oc -n zwmtib-dev port-forward ims-api-XX-XXXXX 8888:8080 &
+#
+PPR_API_IMS_API_URL=http://localhost:8888
+
+# =====================================================================================================================

--- a/ppr-api/openshift/ppr-api-dc.yaml
+++ b/ppr-api/openshift/ppr-api-dc.yaml
@@ -39,6 +39,8 @@ objects:
         - env:
           - name: PORT
             value: "8080"
+          - name: PPR_API_IMS_API_URL
+            value: http://ims-api.zwmtib-${ENVIRONMENT}.svc:8080
           - name: WEB_CONCURRENCY
             value: "4"
           imagePullPolicy: Always

--- a/ppr-api/requirements.txt
+++ b/ppr-api/requirements.txt
@@ -1,6 +1,6 @@
 
 email-validator==1.0.5 # Uvicorn complains without this.
-python-dotenv==0.10.3
 psycopg2-binary==2.8.4
+python-dotenv==0.10.3
 requests==2.22.0
 sqlalchemy==1.3.10

--- a/ppr-api/requirements.txt
+++ b/ppr-api/requirements.txt
@@ -1,3 +1,4 @@
 
 email-validator==1.0.5 # Uvicorn complains without this.
+python-dotenv==0.10.3
 requests==2.22.0

--- a/ppr-api/src/config.py
+++ b/ppr-api/src/config.py
@@ -1,0 +1,15 @@
+"""
+Handle environment-specific configuration settings.
+
+Uses dotenv to read the configuration settings:
+ - for local development, the filesystem will be walked up until a .env file is found.
+ - for OpenShift deployment, the value is read from a deploymentconfig environment variable.
+"""
+
+import os
+
+import dotenv
+
+dotenv.load_dotenv()
+
+IMS_API_URL = os.getenv("PPR_API_IMS_API_URL")

--- a/ppr-api/src/endpoints/search.py
+++ b/ppr-api/src/endpoints/search.py
@@ -6,6 +6,7 @@ import fastapi
 import requests
 from starlette import responses
 
+import config
 
 router = fastapi.APIRouter()
 
@@ -19,9 +20,7 @@ async def search(serial: str, response: responses.Response):
         Parameters:
             serial: The serial number to search for.
     """
-    ims_response = requests.get(
-        "https://ims-api-dev.pathfinder.gov.bc.ca/search?serial={}".format(serial)
-    )
+    ims_response = requests.get(config.IMS_API_URL + "/search?serial={}".format(serial))
 
     response.status_code = ims_response.status_code
 


### PR DESCRIPTION
The PPR API was currently hard-coded to call the dev instance of the IMS API.
 - Set up the API to read the IMS location from an environment variable.
 - Set up the API to use dotenv to read .env files.
 - Add the environment variable to the deploy config.
 - Document the .env file for developer use.