### PR TITLE
Refactor the PPR API database configuration to leverage dotenv

### DIFF
--- a/ppr-api/README.md
+++ b/ppr-api/README.md
@@ -47,13 +47,13 @@ worker processes running.
 
 These settings are for building connections to the database.
 
-| Environment Variable | Description                                   |
-| -------------------- | --------------------------------------------- |
-| DB_HOSTNAME          | Host where the database is located: localhost |
-| DB_PORT              | Port to listen on: 5432                       |
-| DB_NAME              | The name of the database: ppr                 |
-| DB_USERNAME          | The username to connect with: postgres        |
-| DB_PASSWORD          | The password of the user. **Required**        |
+| Environment Variable | Description                        |
+| -------------------- | ---------------------------------- |
+| PPR_API_DB_HOSTNAME  | Host where the database is located |
+| PPR_API_DB_PORT      | Port to listen on: 5432            |
+| PPR_API_DB_NAME      | The name of the database           |
+| PPR_API_DB_USERNAME  | The username to connect with       |
+| PPR_API_DB_PASSWORD  | The password of the user           |
 
 ### Sentry Configuration
 

--- a/ppr-api/docs/dotenv_template
+++ b/ppr-api/docs/dotenv_template
@@ -10,5 +10,10 @@
 #     $ oc -n zwmtib-dev port-forward ims-api-XX-XXXXX 8888:8080 &
 #
 PPR_API_IMS_API_URL=http://localhost:8888
+PPR_API_DB_HOSTNAME=localhost
+PPR_API_DB_PORT=5432
+PPR_API_DB_NAME=ppr
+PPR_API_DB_USERNAME=postgres
+PPR_API_DB_PASSWORD=password
 
 # =====================================================================================================================

--- a/ppr-api/openshift/ppr-api-dc.yaml
+++ b/ppr-api/openshift/ppr-api-dc.yaml
@@ -44,7 +44,7 @@ objects:
           - name: WEB_CONCURRENCY
             value: "4"
           envFrom:
-            - prefix: DB_
+            - prefix: PPR_API_DB_
               secretRef:
                 name: ppr-database
           imagePullPolicy: Always

--- a/ppr-api/src/config.py
+++ b/ppr-api/src/config.py
@@ -13,3 +13,8 @@ import dotenv
 dotenv.load_dotenv()
 
 IMS_API_URL = os.getenv("PPR_API_IMS_API_URL")
+DB_HOSTNAME = os.getenv('PPR_API_DB_HOSTNAME')
+DB_PORT = int(os.getenv('PPR_API_DB_PORT', '5432'))
+DB_NAME = os.getenv('PPR_API_DB_NAME')
+DB_USERNAME = os.getenv('PPR_API_DB_USERNAME')
+DB_PASSWORD = os.getenv('PPR_API_DB_PASSWORD')

--- a/ppr-api/src/models/database.py
+++ b/ppr-api/src/models/database.py
@@ -1,18 +1,14 @@
-import os
-
 import sqlalchemy
 import sqlalchemy.orm
 
-DB_PASSWORD = os.getenv('DB_PASSWORD')
-if not DB_PASSWORD:
-    raise Exception('DB_PASSWORD environment variable is required')
+import config
 
 DATABASE_URI = 'postgresql://{user}:{password}@{host}:{port}/{name}'.format(
-    user=os.getenv('DB_USERNAME', 'postgres'),
-    password=DB_PASSWORD,
-    host=os.getenv('DB_HOSTNAME', 'localhost'),
-    port=int(os.getenv('DB_PORT', '5432')),
-    name=os.getenv('DB_NAME', 'ppr')
+    user=config.DB_USERNAME,
+    password=config.DB_PASSWORD,
+    host=config.DB_HOSTNAME,
+    port=config.DB_PORT,
+    name=config.DB_NAME
 )
 
 engine = sqlalchemy.create_engine(DATABASE_URI)

--- a/ppr-api/tests/unit/conftest.py
+++ b/ppr-api/tests/unit/conftest.py
@@ -1,6 +1,0 @@
-import os
-
-
-def pytest_configure(config):
-    os.environ["DB_PASSWORD"] = "test_password"
-    return config


### PR DESCRIPTION
 I refactor the PPR API database configuration to leverage dotenv.

I also removed the constraint that prevented startup of the application if a database password is not provided.  Now, just like any other misconfiguration, it will no longer prevent the app from starting.

@WalterMoar We'll need to re-apply the DC as this gets deployed