### PR TITLE
Removed the OpenShift route. #95

### DIFF
--- a/ims-api/openshift/ims-api-dc.yaml
+++ b/ims-api/openshift/ims-api-dc.yaml
@@ -111,26 +111,6 @@ objects:
       deploymentconfig: ${API_NAME}
     sessionAffinity: None
     type: ClusterIP
-- apiVersion: route.openshift.io/v1
-  kind: Route
-  metadata:
-    labels:
-      app: ppr
-      environment: ${ENVIRONMENT}
-      role: ${API_NAME}
-    name: ${API_NAME}
-  spec:
-    host: ${ROUTE_URL}
-    port:
-      targetPort: 8080-tcp
-    tls:
-      insecureEdgeTerminationPolicy: Redirect
-      termination: edge
-    to:
-      kind: Service
-      name: ${API_NAME}
-      weight: 100
-    wildcardPolicy: None
 parameters:
 - description: The name of the API.
   displayName: API Name
@@ -147,8 +127,3 @@ parameters:
   name: IMAGE_TAG
   required: true
   value: dev
-- description: The URL to use for the route.
-  displayName: Route URL
-  name: ROUTE_URL
-  required: true
-  value: ims-api-dev.pathfinder.gov.bc.ca


### PR DESCRIPTION
Now that the ppr-api is using a service to connect to the ims-api, the route can be removed.

Curious if `oc apply` is enough for this, but it might need to be manually deleted.