### PR TITLE
Added /operations/database endpoint. #96

### DIFF
--- a/ppr-api/openshift/ppr-api-dc.yaml
+++ b/ppr-api/openshift/ppr-api-dc.yaml
@@ -61,7 +61,7 @@ objects:
           livenessProbe:
             failureThreshold: 3
             httpGet:
-              path: /health
+              path: /operations/health
               port: 8080
               scheme: HTTP
             initialDelaySeconds: 20
@@ -75,7 +75,7 @@ objects:
           readinessProbe:
             failureThreshold: 3
             httpGet:
-              path: /health
+              path: /operations/health
               port: 8080
               scheme: HTTP
             initialDelaySeconds: 20

--- a/ppr-api/src/endpoints/api.py
+++ b/ppr-api/src/endpoints/api.py
@@ -8,5 +8,5 @@ from . import healthcheck
 
 router = fastapi.APIRouter()
 
-router.include_router(healthcheck.router, tags=["Operations"])
+router.include_router(healthcheck.router, prefix="/operations", tags=["Operations"])
 router.include_router(search.router, tags=["Search"])

--- a/ppr-api/src/endpoints/healthcheck.py
+++ b/ppr-api/src/endpoints/healthcheck.py
@@ -13,7 +13,7 @@ STATUS_DOWN = "DOWN"
 
 
 @router.get("/health")
-def health(session: sqlalchemy.orm.Session = fastapi.Depends(models.database.get_session)):
+def health():
     """
     Returns a health check for this service - if reachable always indicates up.
     """

--- a/ppr-api/src/endpoints/healthcheck.py
+++ b/ppr-api/src/endpoints/healthcheck.py
@@ -15,12 +15,20 @@ STATUS_DOWN = "DOWN"
 @router.get("/health")
 def health(session: sqlalchemy.orm.Session = fastapi.Depends(models.database.get_session)):
     """
-    Returns a health check for this service and external resources. Downstream resources do not affect the overall
-    status.
+    Returns a health check for this service - if reachable always indicates up.
     """
     return {
-        "status": STATUS_UP,
-        "database": database_status(session)
+        "status": STATUS_UP
+    }
+
+
+@router.get("/database")
+def database(session: sqlalchemy.orm.Session = fastapi.Depends(models.database.get_session)):
+    """
+    Returns a health check for the reachability of the database.
+    """
+    return {
+        "status": database_status(session)
     }
 
 


### PR DESCRIPTION
I split the database check out from the regular health check, as we had pod restarts due to db timeouts.