### PR TITLE
Database check returns HTTP 503 on fail. #96

### DIFF
--- a/ppr-api/src/endpoints/healthcheck.py
+++ b/ppr-api/src/endpoints/healthcheck.py
@@ -30,7 +30,7 @@ def database(response: responses.Response,
     Returns a health check for the reachability of the database.
     """
     try:
-        session.execute('SELECT 1')
+        session.execute("SELECT 1")
 
         return {
             "status": STATUS_UP
@@ -38,7 +38,7 @@ def database(response: responses.Response,
     except Exception as exception:
         # TODO re-add logging when database connection works.  ATM this creates a lot of noise.
         # logger.warning("Database healthcheck failed", exc_info=True)
-        response.status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
+        response.status_code = status.HTTP_503_SERVICE_UNAVAILABLE
 
         return {
             "status": STATUS_DOWN,

--- a/ppr-api/src/endpoints/healthcheck.py
+++ b/ppr-api/src/endpoints/healthcheck.py
@@ -2,6 +2,7 @@ import logging
 
 import fastapi
 import sqlalchemy.orm
+from starlette import responses, status
 
 import models.database
 
@@ -23,20 +24,23 @@ def health():
 
 
 @router.get("/database")
-def database(session: sqlalchemy.orm.Session = fastapi.Depends(models.database.get_session)):
+def database(response: responses.Response,
+             session: sqlalchemy.orm.Session = fastapi.Depends(models.database.get_session)):
     """
     Returns a health check for the reachability of the database.
     """
-    return {
-        "status": database_status(session)
-    }
-
-
-def database_status(session: sqlalchemy.orm.Session):
     try:
         session.execute('SELECT 1')
-        return STATUS_UP
-    except Exception:
+
+        return {
+            "status": STATUS_UP
+        }
+    except Exception as exception:
         # TODO re-add logging when database connection works.  ATM this creates a lot of noise.
         # logger.warning("Database healthcheck failed", exc_info=True)
-        return STATUS_DOWN
+        response.status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
+
+        return {
+            "status": STATUS_DOWN,
+            "error": str(exception)
+        }

--- a/ppr-api/tests/unit/endpoints/test_healthcheck.py
+++ b/ppr-api/tests/unit/endpoints/test_healthcheck.py
@@ -1,16 +1,26 @@
-import endpoints.healthcheck
+from starlette import responses, status
+
+from endpoints import healthcheck
 
 
 def test_database_status_without_exception():
     expected = "UP"
-    actual = endpoints.healthcheck.database_status(MockSession())
-    assert expected == actual
+    response = responses.Response()
+
+    actual = healthcheck.database(response, MockSession())
+
+    assert expected == actual["status"]
+    assert status.HTTP_200_OK == response.status_code
 
 
-def test_database_status_throws_exception():
+def test_database_status_with_exception():
     expected = "DOWN"
-    actual = endpoints.healthcheck.database_status(MockSession(True))
-    assert expected == actual
+    response = responses.Response()
+
+    actual = healthcheck.database(response, MockSession(True))
+
+    assert expected == actual["status"]
+    assert status.HTTP_503_SERVICE_UNAVAILABLE == response.status_code
 
 
 class MockSession:
@@ -19,5 +29,5 @@ class MockSession:
 
     def execute(self, sql):
         if self.should_fail:
-            raise Exception('execute failed intentionally')
+            raise Exception("execute failed intentionally")
         return None


### PR DESCRIPTION
Updated the database check to not return 200 on fail. Using a 503 (service unavailable) as a 500 (internal server error) still just doesn't feel right when there is no error internal to the server.