### PR TITLE
Add links to home page, update unit test

### DIFF
--- a/ppr-ui/src/views/Home.vue
+++ b/ppr-ui/src/views/Home.vue
@@ -32,13 +32,37 @@
               <header>
                 <h2>Sample Aside Section</h2>
               </header>
+              <div>
+                <ul>
+                  <li>
+                    <router-link to="home">
+                      Home
+                    </router-link>
+                  </li>
+                  <li v-if="flags.feature2">
+                    <router-link to="search">
+                      Search
+                    </router-link>
+                  </li>
+                  <li v-if="flags.feature2">
+                    <router-link to="results">
+                      Results
+                    </router-link>
+                  </li>
+                  <li>
+                    <router-link to="about">
+                      About
+                    </router-link>
+                  </li>
+                </ul>
+              </div>
             </section>
           </aside>
         </div>
       </article>
     </v-container>
 
-    <v-container v-if="flags.feature2">
+    <v-container v-if="feature2">
       <v-btn
         class="form-primary-btn"
         color="primary"
@@ -61,14 +85,15 @@ export default createComponent({
     const {router} = useRouter()
     // Feature Flags
     const flags = useFeatureFlags()
-    const featureOneLabel = computed((): string => (flags.feature1 ? 'enabled' : ' disabled'))
+    const featureOneLabel = computed((): string => (flags.feature1 ? 'enabled' : 'disabled'))
     const featureTwoLabel = computed((): string => (flags.feature2 ? 'enabled' : 'disabled'))
+    const feature2 = computed( (): boolean => flags ? flags.feature2: false)
 
     function goSearch(): void {
       router.push('search')
     }
 
-    return { flags, featureOneLabel, featureTwoLabel, goSearch }
+    return { flags, feature2, featureOneLabel, featureTwoLabel, goSearch }
   }
 })
 </script>

--- a/ppr-ui/tests/unit/example.spec.ts
+++ b/ppr-ui/tests/unit/example.spec.ts
@@ -1,31 +1,25 @@
 // test/FeatureOne.spec.js
 
-// Libraries
 import Vue from 'vue'
 import Vuetify from 'vuetify'
 import VueCompositionApi from '@vue/composition-api'
-// Utilities
-import {createLocalVue, mount} from '@vue/test-utils'
-// Components
+import {shallowMount} from '@vue/test-utils'
 import Home from '@/views/Home.vue'
-// Application
+
 import {FeatureFlags, FeatureFlagSymbol} from "@/flags/feature-flags"
+const featureFlags = FeatureFlags.Instance
+
 import {RouterSymbol} from '@/router/router'
 import router from '@/router/router'
 
 Vue.use(Vuetify)
 Vue.use(VueCompositionApi)
-const localVue = createLocalVue()
 
 describe('FeatureOne.vue', (): void => {
-  let vuetify, wrapper
-  const featureFlags = FeatureFlags.Instance
+  let wrapper
 
   beforeEach((): void => {
-    vuetify = new Vuetify()
-    wrapper = mount(Home, {
-      localVue,
-      vuetify,
+    wrapper = shallowMount(Home, {
       provide: {
         [FeatureFlagSymbol]: featureFlags,
         [RouterSymbol]: router
@@ -39,9 +33,16 @@ describe('FeatureOne.vue', (): void => {
     expect(featureFlags.feature1).toBeTruthy()
   })
 
+  it('Test flagging feature two', (): void => {
+    expect(featureFlags.feature2).toBeFalsy()
+    featureFlags.feature2 = true
+    expect(featureFlags.feature2).toBeTruthy()
+  })
+
   it('the feature is enabled', (): void => {
+    featureFlags.feature1 = true
     const element = wrapper.find('#fflag1')
-    // console.log('Found element', element.text())
+    console.log(`Found element '${element.text()}'`)
     expect(element.text()).toContain('enabled')
   })
 


### PR DESCRIPTION
Change unit test to use shallowMount to focus on page level components. This is the recommended practice and, besides, with mount and the inclusion of router-link on the page the set up to mount the element becomes very complex.