### PR TITLE
Added jacoco reference to build.gradle to do coverage reports for Java…

### DIFF
--- a/ims-api/build.gradle
+++ b/ims-api/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'application'
     id 'org.springframework.boot' version '2.1.9.RELEASE'
     id 'io.spring.dependency-management' version '1.0.8.RELEASE'
+    id 'jacoco'
 }
 
 repositories {
@@ -28,6 +29,18 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:3.1.0'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+}
+
+jacocoTestCoverageVerification{}
+
+jacocoTestReport {
+    reports {
+        xml.enabled true
+        html.enabled true
+        csv.enabled false
+        xml.destination file("${buildDir}/coverage.xml")
+        html.destination file("${buildDir}/reports/coverage")
+    }
 }
 
 application {


### PR DESCRIPTION
… #168

jacoco coverage test reports can be invoked by `./gradlew jacocoTestReport`

The combination call for test and coverage is : `./gradlew test jacocoTestReport`

