### PR TITLE
Prepare serial model for unit testing

### DIFF
--- a/ppr-ui/src/App.vue
+++ b/ppr-ui/src/App.vue
@@ -83,8 +83,5 @@ export default createComponent({
 
 </script>
 <style lang="scss">
-  .ff {
-    margin-bottom: 1rem;
-  }
 </style>
 

--- a/ppr-ui/src/search/SearchSerial.vue
+++ b/ppr-ui/src/search/SearchSerial.vue
@@ -26,7 +26,6 @@
 
 <script lang="ts">
 import {computed, createComponent, ref} from "@vue/composition-api"
-import AppData from '@/utils/app-data'
 import {Data} from "@vue/composition-api/dist/ts-api/component"
 import {useLoadIndicator} from "@/load-indicator"
 import {useRouter} from '@/router/router'

--- a/ppr-ui/src/search/SearchSerial.vue
+++ b/ppr-ui/src/search/SearchSerial.vue
@@ -26,6 +26,7 @@
 
 <script lang="ts">
 import {computed, createComponent, ref} from "@vue/composition-api"
+import AppData from '@/utils/app-data'
 import {Data} from "@vue/composition-api/dist/ts-api/component"
 import {useLoadIndicator} from "@/load-indicator"
 import {useRouter} from '@/router/router'
@@ -51,9 +52,10 @@ export default createComponent({
     })
 
     function doSearch(): void {
+      let baseUrl = AppData.config.pprApiUrl
       loadIndicator.start()
       errorMessage.value = ''
-      searcherSerial.doSearch(serialNumber.value)
+      searcherSerial.doSearch(baseUrl, serialNumber.value)
         .then((): void => {
           router.push('results')
         })

--- a/ppr-ui/src/search/SearchSerial.vue
+++ b/ppr-ui/src/search/SearchSerial.vue
@@ -52,10 +52,9 @@ export default createComponent({
     })
 
     function doSearch(): void {
-      let baseUrl = AppData.config.pprApiUrl
       loadIndicator.start()
       errorMessage.value = ''
-      searcherSerial.doSearch(baseUrl, serialNumber.value)
+      searcherSerial.doSearch(serialNumber.value)
         .then((): void => {
           router.push('results')
         })

--- a/ppr-ui/src/search/search-serial.ts
+++ b/ppr-ui/src/search/search-serial.ts
@@ -1,5 +1,5 @@
 import {inject, provide, reactive} from "@vue/composition-api"
-import axios from "@/utils/axios-auth"
+import axiosAuth from "@/utils/axios-auth"
 import AppData from '@/utils/app-data'
 
 function baseUrl(): string {
@@ -72,7 +72,7 @@ export class SearcherSerial {
     let url = baseUrl + 'search'
     console.log('Make the search api call', url)
     return new Promise((resolve, reject): void => {
-      axios
+      axiosAuth
         .get(url, config)
         .then((response): void => {
           if (response && response.data) {

--- a/ppr-ui/src/search/search-serial.ts
+++ b/ppr-ui/src/search/search-serial.ts
@@ -39,10 +39,12 @@ export class SearcherSerial {
   private _errorMessage: string
   private _results: SerialResult[]
   private _term: string
+  private readonly _baseUrl: string
 
   private readonly _serialNumberRules: VFunction[] // ((v: string) => (string | boolean))[]
 
   public constructor() {
+    this._baseUrl = AppData.config.pprApiUrl
     this._serialNumberRules = [
       (value): (boolean | string) => { return !!value || TEXT.required },
       (value): (boolean | string) => { return value.length <= 25 || TEXT.tooLong },
@@ -54,7 +56,7 @@ export class SearcherSerial {
   public get results(): SerialResult[] { return this._results}
   public get describeValidSerial(): string { return TEXT.describeValidSerial}
 
-  public doSearch(baseUrl: string, term: string): Promise<string> {
+  public doSearch(term: string): Promise<string> {
     // save the search term for reuse when displaying results or errors
     this._term = term
     // console.log('Search for ', this._term)
@@ -69,7 +71,7 @@ export class SearcherSerial {
       }
     }
 
-    let url = baseUrl + 'search'
+    let url = this._baseUrl + 'search'
     console.log('Make the search api call', url)
     return new Promise((resolve, reject): void => {
       axiosAuth

--- a/ppr-ui/src/search/search-serial.ts
+++ b/ppr-ui/src/search/search-serial.ts
@@ -14,7 +14,7 @@ const TEXT = {
   tooLong: 'Serial number can only have 25 characters'
 }
 
-interface SerialResult {
+export interface SerialResult {
   match: string;
   make: string;
   vin: string;
@@ -54,7 +54,7 @@ export class SearcherSerial {
   public get results(): SerialResult[] { return this._results}
   public get describeValidSerial(): string { return TEXT.describeValidSerial}
 
-  public doSearch(term: string): Promise<string> {
+  public doSearch(baseUrl: string, term: string): Promise<string> {
     // save the search term for reuse when displaying results or errors
     this._term = term
     // console.log('Search for ', this._term)
@@ -69,7 +69,7 @@ export class SearcherSerial {
       }
     }
 
-    let url = baseUrl()
+    let url = baseUrl + 'search'
     console.log('Make the search api call', url)
     return new Promise((resolve, reject): void => {
       axios

--- a/ppr-ui/src/search/search-serial.ts
+++ b/ppr-ui/src/search/search-serial.ts
@@ -2,10 +2,6 @@ import {inject, provide, reactive} from "@vue/composition-api"
 import axiosAuth from "@/utils/axios-auth"
 import AppData from '@/utils/app-data'
 
-function baseUrl(): string {
-  return AppData.config.pprApiUrl + 'search'
-}
-
 const TEXT = {
   errorMsg: (text): string => `Search serial number error - ${text}`,
   describeValidSerial: 'Serial number can have up to 25 letters or digits',

--- a/ppr-ui/src/utils/axios-auth.ts
+++ b/ppr-ui/src/utils/axios-auth.ts
@@ -1,5 +1,4 @@
 import axios from 'axios'
-// import { AxiosResponse } from 'axios'
 
 const instance = axios.create()
 
@@ -10,16 +9,5 @@ instance.interceptors.request.use(
   },
   (error): Promise<void> => Promise.reject(error)
 )
-
-// instance.interceptors.response.use(
-// // : Promise<AxiosResponse<any>>
-//   (response): AxiosResponse<object> => response,
-//   (error): Promise<void> => Promise.reject(error)
-// )
-//
-//
-// export function setBaseUrl(url: string): void {
-//   axios.defaults.baseURL = url
-// }
 
 export default instance

--- a/ppr-ui/src/utils/axios-auth.ts
+++ b/ppr-ui/src/utils/axios-auth.ts
@@ -1,5 +1,5 @@
 import axios from 'axios'
-import { AxiosResponse } from 'axios'
+// import { AxiosResponse } from 'axios'
 
 const instance = axios.create()
 
@@ -11,15 +11,15 @@ instance.interceptors.request.use(
   (error): Promise<void> => Promise.reject(error)
 )
 
-instance.interceptors.response.use(
-// : Promise<AxiosResponse<any>>
-  (response): AxiosResponse<object> => response,
-  (error): Promise<void> => Promise.reject(error)
-)
-
-
-export function setBaseUrl(url: string): void {
-  axios.defaults.baseURL = url
-}
+// instance.interceptors.response.use(
+// // : Promise<AxiosResponse<any>>
+//   (response): AxiosResponse<object> => response,
+//   (error): Promise<void> => Promise.reject(error)
+// )
+//
+//
+// export function setBaseUrl(url: string): void {
+//   axios.defaults.baseURL = url
+// }
 
 export default instance

--- a/ppr-ui/src/utils/config-helper.ts
+++ b/ppr-ui/src/utils/config-helper.ts
@@ -1,6 +1,5 @@
-import axios from '@/utils/axios-auth'
+import axiosAuth from '@/utils/axios-auth'
 import AppData, {Config} from '@/utils/app-data'
-import {setBaseUrl} from '@/utils/axios-auth'
 
 export default {
   /**
@@ -34,15 +33,13 @@ export default {
       'ResponseType': 'application/json',
       'Cache-Control': 'no-cache'
     }
-    const response = await axios.get(url, {headers})
+    const response = await axiosAuth.get(url, {headers})
 
     // with the above to do workaround the response data is a string and needs to be parse.
     // it is expected that once we do the to do above the response data with be an object
     const rd: object = response.data
     const cf: object = (typeof rd === 'string') ? JSON.parse(rd) : rd
     AppData.resetConfig(cf)
-
-    setBaseUrl(AppData.config.pprApiUrl)
 
     return AppData.config
   }


### PR DESCRIPTION
Removing dependency on imported app data in the model class. Instead require this to be passed into the model class.  This will simplify the structure of unit tests.