### PR TITLE
Enabled error logging for DB check.

### DIFF
--- a/ppr-api/src/endpoints/healthcheck.py
+++ b/ppr-api/src/endpoints/healthcheck.py
@@ -36,8 +36,7 @@ def database(response: responses.Response,
             "status": STATUS_UP
         }
     except Exception as exception:
-        # TODO re-add logging when database connection works.  ATM this creates a lot of noise.
-        # logger.warning("Database healthcheck failed", exc_info=True)
+        logger.warning("EDB database healthcheck failed", exc_info=True)
         response.status_code = status.HTTP_503_SERVICE_UNAVAILABLE
 
         return {


### PR DESCRIPTION
We're getting a lot of Uptime Robot failures for the EDB check. Enabled the logging so that we can try to sort out the problem.

Note that this should not be deployed to test until we have a database there.