### PR TITLE
Ignore any potential .env files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ __pycache__
 
 # Environments
 .venv
+.env
 .env.local
 .env.*.local
 .configuration.json


### PR DESCRIPTION
Ignore any potential .env files (used by python `dotenv` and docker-compose) to ensure environment settings to not accidentally get committed.

#195
