### PR TITLE
112 add code coverage to GitHub actions

### DIFF
--- a/.github/workflows/compile-and-test-stage.yml
+++ b/.github/workflows/compile-and-test-stage.yml
@@ -28,9 +28,9 @@ jobs:
           pip install .
           pytest
       - name: Upload coverage to Codecov
-        working-directory: ppr-api
         uses: codecov/codecov-action@v1
         with:
+          working-directory: ppr-api
           token: ${{ secrets.CODECOV_TOKEN }}
           file: coverage.xml
           flags: python_unittests
@@ -63,9 +63,9 @@ jobs:
       - run: npm run test:unit:cov
         working-directory: ppr-ui
       - name: Upload coverage to Codecov
-        working-directory: ppr-ui
         uses: codecov/codecov-action@v1
         with:
+          working-directory: ppr-api
           token: ${{ secrets.CODECOV_TOKEN }}
           file: coverage/clover.xml
           flags: ui_unittests

--- a/.github/workflows/compile-and-test-stage.yml
+++ b/.github/workflows/compile-and-test-stage.yml
@@ -30,9 +30,8 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
         with:
-          working-directory: ppr-api
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: coverage.xml
+          file: ppr-api/coverage.xml
           flags: python_unittests
           fail_ci_if_error: true
 
@@ -65,8 +64,6 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
         with:
-          working-directory: ppr-api
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: coverage/clover.xml
-          flags: ui_unittests
+          file: ppr-ui/coverage/clover.xml
           fail_ci_if_error: true

--- a/.github/workflows/compile-and-test-stage.yml
+++ b/.github/workflows/compile-and-test-stage.yml
@@ -27,7 +27,14 @@ jobs:
         working-directory: ppr-api
         run: |
           pip install .
-          pytest tests/unit
+          pytest --junitxml=testresults.xml --cov=. --cov-report xml tests/unit
+        - name: Upload coverage to Codecov
+          uses: codecov/codecov-action@v1
+          with:
+            token: ${{ secrets.CODECOV_TOKEN }}
+            file: ./coverage.xml
+            flags: python_unittests
+            fail_ci_if_error: true
 
   ims-api-build:
     runs-on: ubuntu-latest
@@ -53,5 +60,12 @@ jobs:
       working-directory: ppr-ui
     - run: npm run lint -- --no-fix
       working-directory: ppr-ui
-    - run: npm run test:unit
+    - run: npm run test:unit:cov
       working-directory: ppr-ui
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        file: ./coverage/clover.xml
+        flags: ui_unittests
+        fail_ci_if_error: true

--- a/.github/workflows/compile-and-test-stage.yml
+++ b/.github/workflows/compile-and-test-stage.yml
@@ -27,7 +27,7 @@ jobs:
         working-directory: ppr-api
         run: |
           pip install .
-          pytest --junitxml=testresults.xml --cov=. --cov-report xml tests/unit
+          pytest
         - name: Upload coverage to Codecov
           uses: codecov/codecov-action@v1
           with:

--- a/.github/workflows/compile-and-test-stage.yml
+++ b/.github/workflows/compile-and-test-stage.yml
@@ -3,7 +3,6 @@ name: Compile and Unit Test
 on: [push, pull_request]
 
 jobs:
-
   ppr-api-build:
     runs-on: ubuntu-latest
 
@@ -28,13 +27,13 @@ jobs:
         run: |
           pip install .
           pytest
-        - name: Upload coverage to Codecov
-          uses: codecov/codecov-action@v1
-          with:
-            token: ${{ secrets.CODECOV_TOKEN }}
-            file: ./coverage.xml
-            flags: python_unittests
-            fail_ci_if_error: true
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: ./coverage.xml
+          flags: python_unittests
+          fail_ci_if_error: true
 
   ims-api-build:
     runs-on: ubuntu-latest
@@ -54,18 +53,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-node@v1
-    - run: npm ci
-      working-directory: ppr-ui
-    - run: npm run lint -- --no-fix
-      working-directory: ppr-ui
-    - run: npm run test:unit:cov
-      working-directory: ppr-ui
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        file: ./coverage/clover.xml
-        flags: ui_unittests
-        fail_ci_if_error: true
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+      - run: npm ci
+        working-directory: ppr-ui
+      - run: npm run lint -- --no-fix
+        working-directory: ppr-ui
+      - run: npm run test:unit:cov
+        working-directory: ppr-ui
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: ./coverage/clover.xml
+          flags: ui_unittests
+          fail_ci_if_error: true

--- a/.github/workflows/compile-and-test-stage.yml
+++ b/.github/workflows/compile-and-test-stage.yml
@@ -28,10 +28,11 @@ jobs:
           pip install .
           pytest
       - name: Upload coverage to Codecov
+        working-directory: ppr-api
         uses: codecov/codecov-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./coverage.xml
+          file: coverage.xml
           flags: python_unittests
           fail_ci_if_error: true
 
@@ -62,9 +63,10 @@ jobs:
       - run: npm run test:unit:cov
         working-directory: ppr-ui
       - name: Upload coverage to Codecov
+        working-directory: ppr-ui
         uses: codecov/codecov-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./coverage/clover.xml
+          file: coverage/clover.xml
           flags: ui_unittests
           fail_ci_if_error: true

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,8 @@ dist/
 **/coverage/**
 .coverage
 htmlcov
+coverage.xml
+testresults.xml
 
 selenium-debug.log
 chromedriver.log

--- a/ppr-api/setup.cfg
+++ b/ppr-api/setup.cfg
@@ -2,5 +2,5 @@
 max-line-length = 120
 
 [tool:pytest]
-addopts = --cov=ppr-api --cov-report html
+addopts = --cov=. --cov-report html:htmlcov --cov-report xml:coverage.xml
 testpaths = tests/unit


### PR DESCRIPTION
I have added CodeCov to the github actions.
Had to tweak the test commands a bit and the setup.cfg for pytest.

Also the codecov plugin does not use previous set working directories, you have to give the full path in the repository.

You'll find the website at: https://codecov.io/gh/bcgov/ppr
