### PR TITLE
112 add code cov to GitHub actions

### DIFF
--- a/.github/workflows/compile-and-test-stage.yml
+++ b/.github/workflows/compile-and-test-stage.yml
@@ -28,9 +28,9 @@ jobs:
           pip install .
           pytest
       - name: Upload coverage to Codecov
-        working-directory: ppr-api
         uses: codecov/codecov-action@v1
         with:
+          working-directory: ppr-api
           token: ${{ secrets.CODECOV_TOKEN }}
           file: coverage.xml
           flags: python_unittests
@@ -63,9 +63,9 @@ jobs:
       - run: npm run test:unit:cov
         working-directory: ppr-ui
       - name: Upload coverage to Codecov
-        working-directory: ppr-ui
         uses: codecov/codecov-action@v1
         with:
+          working-directory: ppr-api
           token: ${{ secrets.CODECOV_TOKEN }}
           file: coverage/clover.xml
           flags: ui_unittests

--- a/.github/workflows/compile-and-test-stage.yml
+++ b/.github/workflows/compile-and-test-stage.yml
@@ -30,9 +30,8 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
         with:
-          working-directory: ppr-api
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: coverage.xml
+          file: ppr-api/coverage.xml
           flags: python_unittests
           fail_ci_if_error: true
 
@@ -65,8 +64,6 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
         with:
-          working-directory: ppr-api
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: coverage/clover.xml
-          flags: ui_unittests
+          file: ppr-ui/coverage/clover.xml
           fail_ci_if_error: true

--- a/.github/workflows/compile-and-test-stage.yml
+++ b/.github/workflows/compile-and-test-stage.yml
@@ -31,7 +31,6 @@ jobs:
         uses: codecov/codecov-action@v1
         with:
           token: ${{secrets.CODECOV_TOKEN}}
-          file: ppr-api/.
           flags: python_unittests
           fail_ci_if_error: true
 
@@ -65,5 +64,4 @@ jobs:
         uses: codecov/codecov-action@v1
         with:
           token: ${{secrets.CODECOV_TOKEN}}
-          file: ppr-ui/.
           fail_ci_if_error: true

--- a/.github/workflows/compile-and-test-stage.yml
+++ b/.github/workflows/compile-and-test-stage.yml
@@ -27,7 +27,14 @@ jobs:
         working-directory: ppr-api
         run: |
           pip install .
-          pytest tests/unit
+          pytest --junitxml=testresults.xml --cov=. --cov-report xml tests/unit
+        - name: Upload coverage to Codecov
+          uses: codecov/codecov-action@v1
+          with:
+            token: ${{ secrets.CODECOV_TOKEN }}
+            file: ./coverage.xml
+            flags: python_unittests
+            fail_ci_if_error: true
 
   ims-api-build:
     runs-on: ubuntu-latest
@@ -53,5 +60,12 @@ jobs:
       working-directory: ppr-ui
     - run: npm run lint -- --no-fix
       working-directory: ppr-ui
-    - run: npm run test:unit
+    - run: npm run test:unit:cov
       working-directory: ppr-ui
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        file: ./coverage/clover.xml
+        flags: ui_unittests
+        fail_ci_if_error: true

--- a/.github/workflows/compile-and-test-stage.yml
+++ b/.github/workflows/compile-and-test-stage.yml
@@ -27,7 +27,7 @@ jobs:
         working-directory: ppr-api
         run: |
           pip install .
-          pytest --junitxml=testresults.xml --cov=. --cov-report xml tests/unit
+          pytest
         - name: Upload coverage to Codecov
           uses: codecov/codecov-action@v1
           with:

--- a/.github/workflows/compile-and-test-stage.yml
+++ b/.github/workflows/compile-and-test-stage.yml
@@ -30,8 +30,8 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          file: ppr-api/coverage.xml
+          token: ${{secrets.CODECOV_TOKEN}}
+          file: ppr-api/.
           flags: python_unittests
           fail_ci_if_error: true
 
@@ -64,6 +64,6 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          file: ppr-ui/coverage/clover.xml
+          token: ${{secrets.CODECOV_TOKEN}}
+          file: ppr-ui/.
           fail_ci_if_error: true

--- a/.github/workflows/compile-and-test-stage.yml
+++ b/.github/workflows/compile-and-test-stage.yml
@@ -3,7 +3,6 @@ name: Compile and Unit Test
 on: [push, pull_request]
 
 jobs:
-
   ppr-api-build:
     runs-on: ubuntu-latest
 
@@ -28,13 +27,13 @@ jobs:
         run: |
           pip install .
           pytest
-        - name: Upload coverage to Codecov
-          uses: codecov/codecov-action@v1
-          with:
-            token: ${{ secrets.CODECOV_TOKEN }}
-            file: ./coverage.xml
-            flags: python_unittests
-            fail_ci_if_error: true
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: ./coverage.xml
+          flags: python_unittests
+          fail_ci_if_error: true
 
   ims-api-build:
     runs-on: ubuntu-latest
@@ -54,18 +53,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-node@v1
-    - run: npm ci
-      working-directory: ppr-ui
-    - run: npm run lint -- --no-fix
-      working-directory: ppr-ui
-    - run: npm run test:unit:cov
-      working-directory: ppr-ui
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        file: ./coverage/clover.xml
-        flags: ui_unittests
-        fail_ci_if_error: true
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+      - run: npm ci
+        working-directory: ppr-ui
+      - run: npm run lint -- --no-fix
+        working-directory: ppr-ui
+      - run: npm run test:unit:cov
+        working-directory: ppr-ui
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: ./coverage/clover.xml
+          flags: ui_unittests
+          fail_ci_if_error: true

--- a/.github/workflows/compile-and-test-stage.yml
+++ b/.github/workflows/compile-and-test-stage.yml
@@ -28,10 +28,11 @@ jobs:
           pip install .
           pytest
       - name: Upload coverage to Codecov
+        working-directory: ppr-api
         uses: codecov/codecov-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./coverage.xml
+          file: coverage.xml
           flags: python_unittests
           fail_ci_if_error: true
 
@@ -62,9 +63,10 @@ jobs:
       - run: npm run test:unit:cov
         working-directory: ppr-ui
       - name: Upload coverage to Codecov
+        working-directory: ppr-ui
         uses: codecov/codecov-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./coverage/clover.xml
+          file: coverage/clover.xml
           flags: ui_unittests
           fail_ci_if_error: true

--- a/.github/workflows/compile-and-test-stage.yml
+++ b/.github/workflows/compile-and-test-stage.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           token: ${{secrets.CODECOV_TOKEN}}
           flags: python_unittests
-          fail_ci_if_error: true
+          fail_ci_if_error: false
 
   ims-api-build:
     runs-on: ubuntu-latest
@@ -64,4 +64,4 @@ jobs:
         uses: codecov/codecov-action@v1
         with:
           token: ${{secrets.CODECOV_TOKEN}}
-          fail_ci_if_error: true
+          fail_ci_if_error: false

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,8 @@ dist/
 **/coverage/**
 .coverage
 htmlcov
+coverage.xml
+testresults.xml
 
 selenium-debug.log
 chromedriver.log

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=bcgov_ppr&metric=alert_status)](https://sonarcloud.io/dashboard?id=bcgov_ppr)[![Lines of Code](https://sonarcloud.io/api/project_badges/measure?project=bcgov_ppr&metric=ncloc)](https://sonarcloud.io/dashboard?id=bcgov_ppr)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=bcgov_ppr&metric=alert_status)](https://sonarcloud.io/dashboard?id=bcgov_ppr)[![Lines of Code](https://sonarcloud.io/api/project_badges/measure?project=bcgov_ppr&metric=ncloc)](https://sonarcloud.io/dashboard?id=bcgov_ppr)[![codecov](https://codecov.io/gh/bcgov/ppr/branch/master/graph/badge.svg)](https://codecov.io/gh/bcgov/ppr)
 
 # Personal Property Registry (PPR)
 
@@ -21,7 +21,7 @@ project you agree to abide by its terms.
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not
     use this file except in compliance with the License. You may obtain a copy
-    of the License at 
+    of the License at
 
        http://www.apache.org/licenses/LICENSE-2.0
 
@@ -32,4 +32,3 @@ project you agree to abide by its terms.
     under the License.
 
 [![SonarCloud](https://sonarcloud.io/images/project_badges/sonarcloud-white.svg)](https://sonarcloud.io/dashboard?id=bcgov_ppr)
-

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=bcgov_ppr&metric=alert_status)](https://sonarcloud.io/dashboard?id=bcgov_ppr)[![Lines of Code](https://sonarcloud.io/api/project_badges/measure?project=bcgov_ppr&metric=ncloc)](https://sonarcloud.io/dashboard?id=bcgov_ppr)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=bcgov_ppr&metric=alert_status)](https://sonarcloud.io/dashboard?id=bcgov_ppr)[![Lines of Code](https://sonarcloud.io/api/project_badges/measure?project=bcgov_ppr&metric=ncloc)](https://sonarcloud.io/dashboard?id=bcgov_ppr)[![codecov](https://codecov.io/gh/bcgov/ppr/branch/master/graph/badge.svg)](https://codecov.io/gh/bcgov/ppr)
 
 # Personal Property Registry (PPR)
 
@@ -32,4 +32,3 @@ project you agree to abide by its terms.
     under the License.
 
 [![SonarCloud](https://sonarcloud.io/images/project_badges/sonarcloud-white.svg)](https://sonarcloud.io/dashboard?id=bcgov_ppr)
-

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,12 @@
+comment: false
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: auto
+        threshold: 1%

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,12 +1,1 @@
 comment: false
-
-coverage:
-  status:
-    project:
-      default:
-        target: auto
-        threshold: 1%
-    patch:
-      default:
-        target: auto
-        threshold: 1%

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,1 @@
+comment: false

--- a/ppr-api/setup.cfg
+++ b/ppr-api/setup.cfg
@@ -2,5 +2,5 @@
 max-line-length = 120
 
 [tool:pytest]
-addopts = --cov=ppr-api --cov-report html
+addopts = --cov=. --cov-report html:htmlcov --cov-report xml:coverage.xml
 testpaths = tests/unit


### PR DESCRIPTION
The CodeCov being kicked off for this PR will fail, but I set an option that the GitHub actions will pass.
The issue is that:  **Secrets are not passed to workflows that are triggered by a pull request from a fork of this repository.** this causes codecov to fail because I am not supplying the token.

So hopefully on the push, it will do the codecov.