### PR TITLE
Get single search record

### DIFF
--- a/ppr-api/docs/api_contract/ppr-api.v1.yaml
+++ b/ppr-api/docs/api_contract/ppr-api.v1.yaml
@@ -187,17 +187,16 @@ components:
       x-examples: {}
       description: ''
       properties:
-        ref:
-          type: string
-          format: uri
+        id:
+          type: integer
         type:
           type: string
           enum:
-            - SERIAL
             - INDIVIDUAL_DEBTOR
             - BUSINESS_DEBTOR
             - MHR_NUMBER
             - REGISTRATION_NUMBER
+            - SERIAL_NUMBER
             - AIRCRAFT_DOT
         criteria:
           type: object
@@ -221,8 +220,8 @@ components:
           type: string
           format: date-time
       required:
-        - criteria
         - type
+        - criteria
     financing-statement:
       title: financing-statement
       type: object

--- a/ppr-api/src/endpoints/search.py
+++ b/ppr-api/src/endpoints/search.py
@@ -1,12 +1,14 @@
 """ Define the endpoints for searching. """
 
 import json
+from uuid import UUID
 
 import fastapi
 import requests
 from starlette import responses
 
 import config
+import schemas.search
 
 router = fastapi.APIRouter()
 
@@ -25,3 +27,19 @@ async def search(serial: str, response: responses.Response):
     response.status_code = ims_response.status_code
 
     return json.loads(ims_response.content.decode("utf-8"))
+
+
+@router.get("/searches/{search_id}", response_model=schemas.search.Search)
+def read_search(search_id: UUID):
+    """
+    Get the details for a previously submitted search request
+
+        Parameters:
+            search_id: The identifier of the search instance to lookup
+        Returns:
+            schemas.search.Search
+    """
+    search_rec = schemas.search.Search(
+        id=search_id,
+        criteria=schemas.search.SearchCriteria(baseRegistrationNumber="123456B"))
+    return search_rec

--- a/ppr-api/src/models/database.py
+++ b/ppr-api/src/models/database.py
@@ -1,4 +1,5 @@
 import sqlalchemy
+import sqlalchemy.ext.declarative
 import sqlalchemy.orm
 
 import config
@@ -13,6 +14,8 @@ DATABASE_URI = 'postgresql://{user}:{password}@{host}:{port}/{name}'.format(
 
 engine = sqlalchemy.create_engine(DATABASE_URI)
 SessionLocal = sqlalchemy.orm.sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+BaseORM = sqlalchemy.ext.declarative.declarative_base()
 
 
 def get_session():

--- a/ppr-api/src/models/search.py
+++ b/ppr-api/src/models/search.py
@@ -1,0 +1,19 @@
+import sqlalchemy
+from sqlalchemy.dialects import postgresql
+import sqlalchemy.orm
+
+from .database import BaseORM
+
+
+class Search(BaseORM):
+    __tablename__ = "search"
+
+    id = sqlalchemy.Column(sqlalchemy.BigInteger, primary_key=True)
+    criteria = sqlalchemy.Column(postgresql.JSON)
+    creation_date_time = sqlalchemy.Column(sqlalchemy.DateTime)
+    type_code = sqlalchemy.Column('type_long_code', sqlalchemy.String(length=40),
+                                  sqlalchemy.ForeignKey('search_type.long_code'))
+
+    @staticmethod
+    def get_search(db: sqlalchemy.orm.Session, search_id: int):
+        return db.query(Search).filter(Search.id == search_id).first()

--- a/ppr-api/src/schemas/search.py
+++ b/ppr-api/src/schemas/search.py
@@ -1,0 +1,15 @@
+from uuid import UUID
+
+from pydantic import BaseModel
+
+
+class SearchCriteria(BaseModel):
+    baseRegistrationNumber: str = None
+
+
+class SearchBase(BaseModel):
+    criteria: SearchCriteria = SearchCriteria()
+
+
+class Search(SearchBase):
+    id: UUID = None

--- a/ppr-api/src/schemas/search.py
+++ b/ppr-api/src/schemas/search.py
@@ -1,15 +1,28 @@
-from uuid import UUID
+import datetime
 
 from pydantic import BaseModel
 
 
-class SearchCriteria(BaseModel):
-    baseRegistrationNumber: str = None
-
-
 class SearchBase(BaseModel):
-    criteria: SearchCriteria = SearchCriteria()
+    type: str
+    criteria: dict
+
+    class Config:
+        orm_mode = True
+        fields = {
+            'type': {'alias': 'type_code'}
+        }
 
 
 class Search(SearchBase):
-    id: UUID = None
+    id: int
+    searchDateTime: datetime.datetime
+
+    class Config:
+        orm_mode = True
+        fields = {
+            'searchDateTime': {'alias': 'creation_date_time'}
+        }
+        json_encoders = {
+            datetime.datetime: lambda dt: dt.isoformat(timespec='seconds')
+        }


### PR DESCRIPTION
Added an endpoint to pull a search record out of the db: `GET /searches/{id}`

I'm going to work next on adding some unit tests.  To support this, expect some refactoring for dependency injection as per https://fastapi.tiangolo.com/tutorial/dependencies/first-steps/

If you wish, you can create some sample data by running inserts similar to this after running the `alembic` scripts:
```
insert into search (type_long_code, criteria) values ('INDIVIDUAL_DEBTOR', '{"debtorName":{"first":"Homer","second":"J","last":"Simpson"}}');
insert into search (type_long_code, criteria) values ('REGISTRATION_NUMBER', '{"value": "123456A"}');
```