### PR TITLE
Make the default database module access Patroni instead of EDB

### DIFF
--- a/ppr-api/src/config.py
+++ b/ppr-api/src/config.py
@@ -13,7 +13,7 @@ import dotenv
 dotenv.load_dotenv()
 
 DB_HOSTNAME = os.getenv('PPR_API_DB_HOSTNAME')
-DB_HOSTNAME_PATRONI = os.getenv('PPR_API_DB_HOSTNAME_PATRONI')
+DB_HOSTNAME_PATRONI = os.getenv('PPR_API_DB_HOSTNAME_PATRONI', DB_HOSTNAME)
 DB_PORT = int(os.getenv('PPR_API_DB_PORT', '5432'))
 DB_PORT_PATRONI = int(os.getenv('PPR_API_DB_PORT_PATRONI', '5432'))
 DB_NAME = os.getenv('PPR_API_DB_NAME')

--- a/ppr-api/src/endpoints/healthcheck.py
+++ b/ppr-api/src/endpoints/healthcheck.py
@@ -8,6 +8,7 @@ import sqlalchemy.orm
 from starlette import responses, status
 
 import models.database
+import models.edb
 import models.patroni
 
 router = fastapi.APIRouter()
@@ -31,27 +32,9 @@ def health():
 def database(response: responses.Response,
              session: sqlalchemy.orm.Session = fastapi.Depends(models.database.get_session)):
     """
-    Returns a health check for the reachability of the database.
+    Returns a health check for the reachability of the default system database.
     """
-    try:
-        start: float = time.perf_counter()
-        session.execute("SELECT 1")
-        elapsed_time: float = time.perf_counter() - start
-
-        if elapsed_time > 1:
-            logger.info("Database health check took longer than 1 second: %s", elapsed_time)
-
-        return {
-            "status": STATUS_UP
-        }
-    except Exception as exception:
-        logger.warning("EDB database healthcheck failed", exc_info=True)
-        response.status_code = status.HTTP_503_SERVICE_UNAVAILABLE
-
-        return {
-            "status": STATUS_DOWN,
-            "error": str(exception)
-        }
+    return db_health(response, session, 'Database delegator')
 
 
 @router.get("/patroni")
@@ -60,19 +43,31 @@ def patroni(response: responses.Response,
     """
     Returns a health check for the reachability of the Patroni database.
     """
+    return db_health(response, session, 'Patroni')
+
+
+@router.get("/edb")
+def edb(response: responses.Response, session: sqlalchemy.orm.Session = fastapi.Depends(models.edb.get_session)):
+    """
+    Returns a health check for the reachability of the EDB (or stand-in) database.
+    """
+    return db_health(response, session, 'EDB')
+
+
+def db_health(response: responses.Response, session: sqlalchemy.orm.Session, name: str):
     try:
         start: float = time.perf_counter()
         session.execute("SELECT 1")
         elapsed_time: float = time.perf_counter() - start
 
         if elapsed_time > 1:
-            logger.info("Patroni health check took longer than 1 second: %s", elapsed_time)
+            logger.info("%s health check took longer than 1 second: %s", name, elapsed_time)
 
         return {
             "status": STATUS_UP
         }
     except Exception as exception:
-        logger.warning("Patroni healthcheck failed", exc_info=True)
+        logger.warning("%s health check failed", name, exc_info=True)
         response.status_code = status.HTTP_503_SERVICE_UNAVAILABLE
 
         return {

--- a/ppr-api/src/models/database.py
+++ b/ppr-api/src/models/database.py
@@ -1,30 +1,14 @@
-import sqlalchemy
+"""
+A proxy class for database access for use while we have multiple databases configured.  For the time being it will
+point to the patroni configuration, but can be changed down the road when we switch to EDB.
+"""
+
 import sqlalchemy.ext.declarative
-import sqlalchemy.orm
 
-import config
+import models.patroni
 
-DATABASE_URI = 'postgresql://{user}:{password}@{host}:{port}/{name}'.format(
-    user=config.DB_USERNAME,
-    password=config.DB_PASSWORD,
-    host=config.DB_HOSTNAME,
-    port=config.DB_PORT,
-    name=config.DB_NAME
-)
-
-engine = sqlalchemy.create_engine(DATABASE_URI)
-SessionLocal = sqlalchemy.orm.sessionmaker(autocommit=False, autoflush=False, bind=engine)
+DATABASE_URI = models.patroni.DATABASE_URI
 
 BaseORM = sqlalchemy.ext.declarative.declarative_base()
 
-
-def get_session():
-    """
-    Returns a session using yield to facilitate using it as a dependency in FastAPI.  See
-    https://fastapi.tiangolo.com/tutorial/dependencies/dependencies-with-yield/
-    """
-    db = SessionLocal()
-    try:
-        yield db
-    finally:
-        db.close()
+get_session = models.patroni.get_session

--- a/ppr-api/src/models/edb.py
+++ b/ppr-api/src/models/edb.py
@@ -1,0 +1,29 @@
+""" Set up SQL Alchemy to access the EDB (or stand-in PostgreSQL) database. """
+
+import sqlalchemy
+import sqlalchemy.orm
+
+import config
+
+DATABASE_URI = 'postgresql://{user}:{password}@{host}:{port}/{name}'.format(
+    user=config.DB_USERNAME,
+    password=config.DB_PASSWORD,
+    host=config.DB_HOSTNAME,
+    port=config.DB_PORT,
+    name=config.DB_NAME
+)
+
+engine = sqlalchemy.create_engine(DATABASE_URI)
+SessionLocal = sqlalchemy.orm.sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+def get_session():
+    """
+    Returns a session using yield to facilitate using it as a dependency in FastAPI.  See
+    https://fastapi.tiangolo.com/tutorial/dependencies/dependencies-with-yield/
+    """
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()


### PR DESCRIPTION
@WalterMoar A few points on this one:
- the `/operations/database` endpoint will now use patroni, so you'll need to use `/operations/edb` for the EDB database
- I set `DB_HOSTNAME_PATRONI` to default to `DB_HOSTNAME` if the env variable is not set, this is so working locally will work ongoing, but still leverages the same config available in our environments.

