### PR TITLE
Refactor search endpoint to support dependency injection

### DIFF
--- a/ppr-api/src/endpoints/search.py
+++ b/ppr-api/src/endpoints/search.py
@@ -4,12 +4,11 @@ import json
 
 import fastapi
 import requests
-import sqlalchemy.orm
 from starlette import responses
 
 import config
 import schemas.search
-import models.search
+import repository.search_repository
 
 router = fastapi.APIRouter()
 
@@ -31,7 +30,7 @@ async def search(serial: str, response: responses.Response):
 
 
 @router.get("/searches/{search_id}", response_model=schemas.search.Search, response_model_by_alias=False)
-def read_search(search_id: int, session: sqlalchemy.orm.Session = fastapi.Depends(models.database.get_session)):
+def read_search(search_id: int, search_repository: repository.search_repository.SearchRepository = fastapi.Depends()):
     """
     Get the details for a previously submitted search request
 
@@ -40,7 +39,7 @@ def read_search(search_id: int, session: sqlalchemy.orm.Session = fastapi.Depend
         Returns:
             schemas.search.Search
     """
-    search_db_row = models.search.Search.get_search(session, search_id)
+    search_db_row = search_repository.get_search(search_id)
     if search_db_row is None:
         raise fastapi.HTTPException(status_code=404, detail="Search record not found")
     return search_db_row

--- a/ppr-api/src/models/search.py
+++ b/ppr-api/src/models/search.py
@@ -13,7 +13,3 @@ class Search(BaseORM):
     creation_date_time = sqlalchemy.Column(sqlalchemy.DateTime)
     type_code = sqlalchemy.Column('type_long_code', sqlalchemy.String(length=40),
                                   sqlalchemy.ForeignKey('search_type.long_code'))
-
-    @staticmethod
-    def get_search(db: sqlalchemy.orm.Session, search_id: int):
-        return db.query(Search).filter(Search.id == search_id).first()

--- a/ppr-api/src/repository/search_repository.py
+++ b/ppr-api/src/repository/search_repository.py
@@ -1,0 +1,14 @@
+import fastapi
+import sqlalchemy.orm
+
+import models.search
+
+
+class SearchRepository:
+    db: sqlalchemy.orm.Session
+
+    def __init__(self, session: sqlalchemy.orm.Session = fastapi.Depends(models.database.get_session)):
+        self.db = session
+
+    def get_search(self, search_id: int):
+        return self.db.query(models.search.Search).filter(models.search.Search.id == search_id).first()

--- a/ppr-api/tests/unit/endpoints/test_search.py
+++ b/ppr-api/tests/unit/endpoints/test_search.py
@@ -1,0 +1,34 @@
+import datetime
+
+import fastapi
+import pytest
+
+import endpoints.search
+import models.search
+
+
+def test_read_search_returns_value():
+    search_record = models.search.Search(id=27, type_code='REGISTRATION_NUMBER', criteria={
+                                         'value': '1234'}, creation_date_time=datetime.datetime.now())
+    repo = MockSearchRepository(search_record)
+    actual = endpoints.search.read_search(27, repo)
+
+    assert search_record == actual
+
+
+def test_read_search_not_found():
+    repo = MockSearchRepository(None)
+    try:
+        endpoints.search.read_search(27, repo)
+    except fastapi.HTTPException as ex:
+        assert ex.status_code == 404
+    else:
+        pytest.fail('A Not Found error was expected')
+
+
+class MockSearchRepository:
+    def __init__(self, search_result):
+        self.search = search_result
+
+    def get_search(self, search_id: int):
+        return self.search


### PR DESCRIPTION
Used FastAPIs dependency injection mechanism for accessing the database.  Among other benefits this provides improved support for mocking in unit tests.  An overview on the topic can be found here: ["Dependency Injection"?](https://fastapi.tiangolo.com/tutorial/dependencies/first-steps/#dependency-injection)

This is a departure from the way things are done in `sbc-auth` and `lear`, as both seem to rely heavily on static methods, which are not terribly conducive to this approach.
