### PR TITLE
Add integration tests to the PPR API

### DIFF
--- a/.github/workflows/compile-and-test-stage.yml
+++ b/.github/workflows/compile-and-test-stage.yml
@@ -6,6 +6,14 @@ jobs:
   ppr-api-build:
     runs-on: ubuntu-latest
 
+    env:
+      PPR_API_DB_HOSTNAME: localhost
+      PPR_API_DB_PORT: 5432
+      PPR_API_DB_NAME: ppr
+      PPR_API_DB_USERNAME: postgres
+      PPR_API_DB_PASSWORD: int_test_pw
+      DB_PASSWORD: int_test_pw
+
     steps:
       - uses: actions/checkout@v1
       - name: Set up Python 3.7
@@ -33,6 +41,19 @@ jobs:
           token: ${{secrets.CODECOV_TOKEN}}
           flags: python_unittests
           fail_ci_if_error: false
+      # Run the PPR-API integration tests.  If we find this takes too long, we may consider moving these steps into a
+      # separate workflow
+      - name: Start a PostgreSQL database with docker-compose
+        run: |
+          ./ready_local_db.sh
+      - name: Execute Integration Tests with PyTest
+        working-directory: ppr-api
+        run: |
+          alembic upgrade head
+          pytest tests/integration
+      - name: Shutdown docker-compose
+        run: |
+          docker-compose down
 
   ims-api-build:
     runs-on: ubuntu-latest

--- a/ppr-api/README.md
+++ b/ppr-api/README.md
@@ -22,6 +22,16 @@ You also need to set up the variables used for environment-specific settings:
 will need to fill in missing values.
 
 
+## Running the PPR Database on localhost
+
+You can use Docker Compose to run a PostgreSQL database locally. It requires a `DB_PASSWORD` environment variable which
+can be in your `.env` file.  However, this will require you `.env` file to be in the root project directory.
+
+To prepare your local database:
+1. In the root project folder: `docker-compose up -d`
+1. In your `venv` environment: `alembic upgrade head`
+
+
 ## Running PPR-API
 
 1. Start the uvicorn server with `(cd src && uvicorn main:app --reload)`
@@ -44,17 +54,12 @@ in the *htmlcov* directory.
 1. ???
 
 
-### Local Dependencies
+## Running Integration Tests
 
-The api requires a **PostgreSQL** database which can be launched locally with docker compose. You must specify a
-password for the database using the `DB_PASSWORD` environment variable. This is required by both docker compose PPR API.
+Integration tests rely on a connection to the database and will use the same environment settings as the PPR API. With
+the database running, execute the following in your `venv` environment:
+1. `pytest tests/integration`
 
-Docker compose will also bring up an instance of Jaeger.
-
-From the project root folder:
-```
-$ docker-compose up -d
-```
 
 ## Application Configuration
 

--- a/ppr-api/docs/dotenv_template
+++ b/ppr-api/docs/dotenv_template
@@ -29,4 +29,11 @@ PPR_API_SENTRY_DSN=
 #
 PPR_API_SENTRY_ENVIRONMENT=local.development
 
-# =====================================================================================================================
+
+# =====  docker-compose ===============================================================================================
+
+# To facilitate running dependencies on your local workstation, there is a docker-compose.yml in the root project
+# directory.  Docker Compose also uses .env files, but requires them to be in the directory where you run the command.
+
+# This value should be the same as 'PPR_API_DB_PASSWORD'
+DB_PASSWORD=password

--- a/ppr-api/src/models/database.py
+++ b/ppr-api/src/models/database.py
@@ -11,4 +11,5 @@ DATABASE_URI = models.patroni.DATABASE_URI
 
 BaseORM = sqlalchemy.ext.declarative.declarative_base()
 
+SessionLocal = models.patroni.SessionLocal
 get_session = models.patroni.get_session

--- a/ppr-api/src/models/search.py
+++ b/ppr-api/src/models/search.py
@@ -10,6 +10,5 @@ class Search(BaseORM):
 
     id = sqlalchemy.Column(sqlalchemy.BigInteger, primary_key=True)
     criteria = sqlalchemy.Column(postgresql.JSON)
-    creation_date_time = sqlalchemy.Column(sqlalchemy.DateTime)
-    type_code = sqlalchemy.Column('type_long_code', sqlalchemy.String(length=40),
-                                  sqlalchemy.ForeignKey('search_type.long_code'))
+    creation_date_time = sqlalchemy.Column(sqlalchemy.DateTime, server_default=sqlalchemy.func.now())
+    type_code = sqlalchemy.Column('type_long_code', sqlalchemy.String(length=40))

--- a/ppr-api/tests/integration/api/test_search.py
+++ b/ppr-api/tests/integration/api/test_search.py
@@ -1,0 +1,31 @@
+from starlette.testclient import TestClient
+
+import main
+import models.database
+import models.search
+
+client = TestClient(main.app)
+
+
+def test_read_search():
+    search_rec = create_user("REGISTRATION_NUMBER", {'value': '1234'})
+
+    rv = client.get('/searches/{}'.format(search_rec.id))
+    assert rv.status_code == 200
+    search = rv.json()
+    assert search['id'] == search_rec.id
+    assert search['type'] == "REGISTRATION_NUMBER"
+    assert search['criteria'] == {'value': '1234'}
+    assert search['searchDateTime'] == search_rec.creation_date_time.isoformat(timespec="seconds")
+
+
+def create_user(type_code: str, criteria: dict):
+    db = models.database.SessionLocal()
+    try:
+        search_rec = models.search.Search(type_code=type_code, criteria=criteria)
+        db.add(search_rec)
+        db.commit()
+        db.refresh(search_rec)
+        return search_rec
+    finally:
+        db.close()

--- a/ready_local_db.sh
+++ b/ready_local_db.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# This script is provided to startup the PostgreSQL and wait for it to be available before completing. This is useful in
+# automated scenarios where you need to ensure the database is available before performing certain actions. For example,
+# when running integration tests during continuous integration scripts, we would execute this script before executing
+# the tests.
+#
+# Usage:
+#   ./ready_local_db.sh
+
+# Make sure the PPR Database is UP
+echo "Running Docker Compose"
+docker-compose up -d
+
+# Wait until PostgreSQL is available before moving on
+attempts=0
+until docker container exec ppr_ppr_db_1 psql -U postgres -c 'SELECT 1' > /dev/null 2>&1; do
+  ((attempts=attempts+1))
+  if [ $attempts -ge 10 ]; then
+    echo "Failed to connect to PostgreSQL after 10 attempts, aborting"
+    exit 1
+  fi
+
+  echo "PostgreSQL is unavailable - sleeping"
+  sleep 1
+done
+echo "PostgreSQL is available"


### PR DESCRIPTION
Create the first integration test for the PPR API.  This will allow us to test the API interface through to a database directly.

A couple of points to note about this PR:
- The test creates its own data and does not clean it up.  If this concerns you, lets chat.
- I used the "Compile and Unit Test" workflow for the time being, since the integration tests are still pretty quick.  The job took 1:08 to complete on my fork.  We might as well keep it here for now and isolate them out to a different workflow if things slow down.
- @rstens For the moment, these tests are running after code coverage is pushed up, we can chat a bit about merging the results later
- FYI, I had initially included running the alembic scripts in `ready_local_db.sh`, but then I had to make assumptions about whether or not the script was being run in a virtual environment, so I took it out and ran alembic in isolation.

Enjoy.