### PR TITLE
Ignore all files prefixed with .env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,7 @@ __pycache__
 # Environments
 .venv
 .env
-.env.local
-.env.*.local
+.env.*
 .configuration.json
 
 # Node packages


### PR DESCRIPTION
let's just make a blanket rule.  This is helpful for me with another PR which uses three .env.* files.