### PR TITLE
Deploy PPR UI on bcregistry.ca

### DIFF
--- a/ppr-ui/.env
+++ b/ppr-ui/.env
@@ -1,1 +1,0 @@
-VUE_APP_PATH = ppr

--- a/ppr-ui/README.md
+++ b/ppr-ui/README.md
@@ -30,7 +30,11 @@ npm run lint
 ```
 
 ### Customize configuration
-See [Configuration Reference](https://cli.vuejs.org/config/).
+The PPR web application is currently served via https://bcregistry.ca/cooperatives/ppr. This url represents
+some technical debt and will need to be changed. The subpath ```cooperatives/ppr```
+appears in the three Openshift templates as APP_PATH; also in ```vue.config.js``` and in ```src/utils/config-helper.ts```
+
+Also see [CLI Vue Configuration Reference](https://cli.vuejs.org/config/).
 
 ## Debugging
 

--- a/ppr-ui/openshift/README.md
+++ b/ppr-ui/openshift/README.md
@@ -10,6 +10,8 @@ oc login https://console.pathfinder.gov.bc.ca:8443 --token=....
 cd ppr-ui/openshift
 ```
 
+Take a close look at ```process.sh`` to see how to set up parameters for build and deploy configs.
+
 ## Validation
 
 To any oc apply command you can append ```--validate``` to check for errors in the configuration.  Note that there is a known

--- a/ppr-ui/openshift/ppr-ui-bc.yaml
+++ b/ppr-ui/openshift/ppr-ui-bc.yaml
@@ -7,6 +7,7 @@ objects:
     labels:
       app: ppr
       build: ${APP_NAME}
+      pprgroup: ${PPR_GROUP}
       role: ${APP_NAME}
     name: ${APP_NAME}
   spec:
@@ -23,13 +24,13 @@ objects:
       dockerfile: |
         FROM bcgov-s2i-caddy
         COPY Caddy/Caddyfile /etc/Caddyfile
-        RUN mkdir -p /var/www/html
-        COPY dist /var/www/html
+        RUN mkdir -p /var/www/html${APP_PATH}
+        COPY dist /var/www/html${APP_PATH}
       images:
       - as: null
         from:
           kind: ImageStreamTag
-          name: ${APP_INTER}:${APP_INTER_TAG}
+          name: ${APP_INTER_NAME}:${APP_INTER_TAG}
         paths:
         - destinationDir: ./
           sourcePath: /dist
@@ -50,15 +51,21 @@ objects:
   metadata:
     labels:
       app: ppr
+      pprgroup: ${PPR_GROUP}
       role: ${APP_NAME}
     name: ${APP_NAME}
   spec:
     lookupPolicy:
       local: false
 parameters:
+- description: A label applied to all PPR UI related resources across tools and dev namespaces. Useful to use with oc get all -l apptag=ppr
+  displayName: PPR group
+  name: PPR_GROUP
+  required: true
+  value: ppr
 - description: The name of the intermediate build image for the PPR UI
   displayName: APP Intermediate
-  name: APP_INTER
+  name: APP_INTER_NAME
   required: true
   value: ppr-ui-inter
 - description: The tag of the intermediate build
@@ -71,9 +78,9 @@ parameters:
   name: APP_NAME
   required: true
   value: ppr-ui
-- description: The path at which web application is deployed. Context root for the web applicaton
-  displayName: WEB_APP_CONTEXT_PATH
-  name: WEB_APP_CONTEXT_PATH
-  required: true
-  value: ppr
+- description: The sub-path to the web application
+  displayName: APP Name
+  name: APP_PATH
+  required: false
+  value: /cooperatives/ppr
 

--- a/ppr-ui/openshift/ppr-ui-dc.yaml
+++ b/ppr-ui/openshift/ppr-ui-dc.yaml
@@ -7,6 +7,7 @@ objects:
     labels:
       app: ppr
       deploymentconfig: ${APP_NAME}
+      pprgroup: ${PPR_GROUP}
       role: ${APP_NAME}
     name: ${APP_NAME}
   spec:
@@ -15,6 +16,7 @@ objects:
     selector:
       app: ppr
       deploymentconfig: ${APP_NAME}
+      pprgroup: ${PPR_GROUP}
       environment: ${ENVIRONMENT}
       role: ${APP_NAME}
     strategy:
@@ -32,6 +34,7 @@ objects:
         labels:
           app: ppr
           deploymentconfig: ${APP_NAME}
+          pprgroup: ${PPR_GROUP}
           environment: ${ENVIRONMENT}
           role: ${APP_NAME}
       spec:
@@ -42,7 +45,7 @@ objects:
             livenessProbe:
               failureThreshold: 3
               httpGet:
-                path: /
+                path: ${APP_PATH}
                 port: 2015
                 scheme: HTTP
               periodSeconds: 10
@@ -55,7 +58,7 @@ objects:
             readinessProbe:
               failureThreshold: 3
               httpGet:
-                path: /
+                path: ${APP_PATH}
                 port: 2015
                 scheme: HTTP
               initialDelaySeconds: 5
@@ -72,9 +75,13 @@ objects:
             terminationMessagePath: /dev/termination-log
             terminationMessagePolicy: File
             volumeMounts:
-              - mountPath: /var/www/html/config
-                name: ppr-web-ui-config
+              - mountPath: /var/www/html${APP_PATH}/config
+                name: ${APP_CONFIG}
                 readOnly: true
+              - mountPath: /etc/Caddyfile
+                name: ${CADDY_CONFIG}
+                readOnly: true
+                subPath: Caddyfile
         dnsPolicy: ClusterFirst
         restartPolicy: Always
         schedulerName: default-scheduler
@@ -83,8 +90,12 @@ objects:
         volumes:
           - configMap:
               defaultMode: 420
-              name: ppr-web-ui-config
-            name: ppr-web-ui-config
+              name: ${APP_CONFIG}
+            name: ${APP_CONFIG}
+          - configMap:
+              defaultMode: 420
+              name: ${CADDY_CONFIG}
+            name: ${CADDY_CONFIG}
     test: false
     triggers:
     - imageChangeParams:
@@ -103,6 +114,7 @@ objects:
     labels:
       app: ppr
       environment: ${ENVIRONMENT}
+      pprgroup: ${PPR_GROUP}
       role: ${APP_NAME}
     name: ${APP_NAME}
   spec:
@@ -120,11 +132,13 @@ objects:
   metadata:
     labels:
       app: ppr
+      pprgroup: ${PPR_GROUP}
       environment: ${ENVIRONMENT}
       role: ${APP_NAME}
     name: ${APP_NAME}
   spec:
-    host: ${ROUTE_URL}
+    host: ${ROUTE_HOST}
+    path: ${APP_PATH}
     port:
       targetPort: 2015-tcp
     tls:
@@ -135,7 +149,30 @@ objects:
       name: ${APP_NAME}
       weight: 100
     wildcardPolicy: None
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    labels:
+      app: ppr
+      pprgroup: ${PPR_GROUP}
+      role: ${APP_NAME}
+    name: ${CADDY_CONFIG}
+  data:
+    Caddyfile: |+
+      0.0.0.0:2015
+      root /var/www/html
+      log stdout
+      errors stdout
+      rewrite ${APP_PATH} {
+          regexp .*
+          to {path} ${APP_PATH}/
+      }
 parameters:
+- description: A label applied to all PPR UI related resources across tools and dev namespaces. Useful to use with oc get all -l apptag=ppr
+  displayName: PPR group
+  name: PPR_GROUP
+  required: true
+  value: ppr
 - description: The name of the Web application.
   displayName: APP Name
   name: APP_NAME
@@ -151,23 +188,23 @@ parameters:
   name: IMAGE_TAG
   required: true
   value: dev
-- description: The URL to use for the route.
-  displayName: Route URL
-  name: ROUTE_URL
+- description: The hostname to use for the route.
+  displayName: Route HOST
+  name: ROUTE_HOST
   required: true
   value: ppr-dev.pathfinder.gov.bc.ca
 - description: Volume name for web app config
   displayName: Web application config volume mount name
-  name: VOL_APP_CONFIG
+  name: APP_CONFIG
   required: true
   value: ppr-web-ui-config
-- description: Volume name for caddy config
+- description: Volume and config map name for caddy config
   displayName: Caddy config volume mount name
-  name: VOL_CADDY
+  name: CADDY_CONFIG
   required: true
-  value: ppr-web-caddy-config
-#- description: The path at which web application is deployed. Context root for the web applicaton
-#  displayName: WEB_APP_CONTEXT_PATH
-#  name: WEB_APP_CONTEXT_PATH
-#  required: true
-#  value: ppr
+  value: ppr-ui-caddy-config
+- description: The sub-path to the web application
+  displayName: APP Name
+  name: APP_PATH
+  required: false
+  value: cooperatives/ppr

--- a/ppr-ui/openshift/ppr-ui-inter-bc.yaml
+++ b/ppr-ui/openshift/ppr-ui-inter-bc.yaml
@@ -7,6 +7,7 @@ objects:
     labels:
       app: ppr
       build: ${APP_NAME}
+      pprgroup: ${PPR_GROUP}
       role: ${APP_NAME}
     name: ${APP_NAME}
   spec:
@@ -32,29 +33,50 @@ objects:
         RUN npm install
         RUN npm run build
       git:
-        uri: https://github.com/bcgov/ppr
-        # sample how to use a developer's fork
-        # uri: https://github.com/somedeveloper/ppr
-        # Defaults to shallow clone of master so no need to ref master. If you do set ref to master then clone is deep
-        # Sample to show how to override to a branch
-        # ref: branch
+        uri: ${GIT_URI}
+        ref: ${GIT_REF}
       type: Git
     strategy:
-      dockerStrategy: {}
+      dockerStrategy:
+        env:
+          - name: APP_PATH
+            value: ${APP_PATH}
+      type: Docker
     successfulBuildsHistoryLimit: 5
 - apiVersion: image.openshift.io/v1
   kind: ImageStream
   metadata:
     labels:
       app: ppr
+      pprgroup: ${PPR_GROUP}
       role: ${APP_NAME}
     name: ${APP_NAME}
   spec:
     lookupPolicy:
       local: false
 parameters:
+- description: A label applied to all PPR UI related resources across tools and dev namespaces. Useful to use with oc get all -l apptag=ppr
+  displayName: PPR group
+  name: PPR_GROUP
+  required: true
+  value: ppr
 - description: The name of the intermediate build image for the PPR UI
   displayName: APP Name
   name: APP_NAME
   required: true
   value: ppr-ui-inter
+- description: The git repository URI
+  displayName: Git URI
+  name: GIT_URI
+  required: true
+  value: https://github.com/bcgov/ppr
+- description: The git repository ref (branch)
+  displayName: Git ref (branch)
+  name: GIT_REF
+  required: true
+  value: master
+- description: The sub-path to the web application
+  displayName: APP Name
+  name: APP_PATH
+  required: false
+  value: cooperatives/ppr

--- a/ppr-ui/openshift/process.sh
+++ b/ppr-ui/openshift/process.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+
+# Git repo values as used in the yaml config files:
+#REPO=https://github.com/bcgov/ppr
+#BRANCH=master
+
+REPO=https://github.com/bryan-gilbert/ppr
+BRANCH=caddyExper
+
+
+APP_PATH=/cooperatives/ppr
+# To revert to a root context (say when PPR has it's own domain
+# APP_PATH=/
+# To revert to a PPR specific context (say when PPR can be hosted at bcregistry.ca/ppr
+# APP_PATH=/ppr
+
+APP_BASE=ppr-ui
+APP_BASE=ppr-oct
+
+APP_TAG=
+APP_TAG=-bg
+
+APP_NAME=$APP_BASE$APP_TAG
+APP_UI_NAME=$APP_BASE$APP_TAG
+APP_INTER_NAME=$APP_BASE-inter$APP_TAG
+
+# PPR_GROUP
+# This label is applied to all resources (buildconfigs, deployconfigs, images, routes, services, etc
+# created by these openshift configuration files.  Usage includes get, describe and delete all
+# of these resources.  See the echo at the end of this file.
+PPR_GROUP=$APP_NAME
+
+HOST=dev.bcregistry.ca
+DEPLOY_TARGET=1rdehl-dev
+
+# To deploy to ppr dev project:
+#HOST=ppr-dev.pathfinder.gov.bc.ca
+#DEPLOY_TARGET=zwmtib-dev
+
+# Generate temporary env files for use with oc process
+# For the intermediate buildconfig
+echo "PPR_GROUP=$PPR_GROUP
+APP_NAME=$APP_INTER_NAME
+APP_PATH=$APP_PATH
+GIT_URI=$REPO
+GIT_REF=$BRANCH
+" > .env.inter
+
+# For buildconfig
+echo "PPR_GROUP=$PPR_GROUP
+APP_NAME=$APP_UI_NAME
+APP_INTER_NAME=$APP_INTER_NAME
+APP_INTER_TAG=latest
+APP_PATH=$APP_PATH
+" > .env.bc
+
+# For deploy
+echo "PPR_GROUP=$PPR_GROUP
+APP_NAME=$APP_UI_NAME
+APP_PATH=$APP_PATH
+CADDY_CONFIG=$APP_NAME-caddy-config$APP_TAG
+IMAGE_TAG=latest
+ROUTE_HOST=$HOST
+" > .env.dc
+
+# Process and apply the build configs
+echo "oc process -f ppr-ui-inter-bc.yaml --param-file=.env.inter | oc -n zwmtib-tools apply -f -"
+echo ".env.inter"
+cat .env.inter
+#oc process -f ppr-ui-inter-bc.yaml --param-file=.env.inter | oc -n zwmtib-tools apply -f -
+
+echo "oc process -f ppr-ui-bc.yaml --param-file=.env.bc | oc -n zwmtib-tools apply -f -"
+echo ".env.bc"
+cat .env.bc
+#oc process -f ppr-ui-bc.yaml --param-file=.env.bc | oc -n zwmtib-tools apply -f -
+
+# Kick off the intermediate build from the command line and see our logs (because it takes up to 12 minutes)
+# and then kick off the caddy image build
+echo "oc start-build $APP_INTER_NAME --follow --wait  &&  oc start-build $APP_UI_NAME"
+#oc start-build $APP_INTER_NAME --follow --wait  &&  oc start-build $APP_UI_NAME
+
+# Process and apply the deployment config
+echo "oc process -f ppr-ui-dc.yaml --param-file=.env.dc | oc -n $DEPLOY_TARGET apply -f -"
+echo ".env.dc"
+cat .env.dc
+#oc process -f ppr-ui-dc.yaml --param-file=.env.dc | oc -n $DEPLOY_TARGET apply -f -
+
+
+echo "
+
+# To list all related resources
+    oc -n zwmtib-tools get all -l pprgroup=$PPR_GROUP
+    oc -n 1rdehl-dev get all,configmap -l pprgroup=$PPR_GROUP
+# To clean up all related resources
+    oc -n zwmtib-tools delete all -l pprgroup=$PPR_GROUP
+    oc -n 1rdehl-dev delete all,configmap -l pprgroup=$PPR_GROUP
+"

--- a/ppr-ui/openshift/process.sh
+++ b/ppr-ui/openshift/process.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 
 # Git repo values as used in the yaml config files:
-#REPO=https://github.com/bcgov/ppr
-#BRANCH=master
+REPO=https://github.com/bcgov/ppr
+BRANCH=master
 
-REPO=https://github.com/bryan-gilbert/ppr
-BRANCH=caddyExper
+#REPO=https://github.com/bryan-gilbert/ppr
+#BRANCH=caddyExper
 
 
 APP_PATH=/cooperatives/ppr
@@ -15,10 +15,10 @@ APP_PATH=/cooperatives/ppr
 # APP_PATH=/ppr
 
 APP_BASE=ppr-ui
-APP_BASE=ppr-oct
+#APP_BASE=ppr-oct
 
 APP_TAG=
-APP_TAG=-bg
+#APP_TAG=-bg
 
 APP_NAME=$APP_BASE$APP_TAG
 APP_UI_NAME=$APP_BASE$APP_TAG

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "serve": "vue-cli-service serve",
+    "serve": "APP_PATH=/ vue-cli-service serve",
     "build": "vue-cli-service build",
     "test": "npm run test:unit && npm run test:e2e",
     "test:unit": "vue-cli-service test:unit",

--- a/ppr-ui/src/App.vue
+++ b/ppr-ui/src/App.vue
@@ -22,8 +22,8 @@ import {provideSearcherSerial} from "@/search/search-serial"
 import AppData from "@/utils/app-data"
 import { initializeVueLdClient } from '@/flags/ld-client'
 import uuid from 'uuid'
+import { APP_PATH } from '@/utils/config-helper'
 
-const APP_PATH = process.env.VUE_APP_PATH || 'app-path-foo-bar'
 const DefaultLayout = 'public'
 
 function origin(): string {

--- a/ppr-ui/src/utils/config-helper.ts
+++ b/ppr-ui/src/utils/config-helper.ts
@@ -1,42 +1,24 @@
 import axiosAuth from '@/utils/axios-auth'
 import AppData, {Config} from '@/utils/app-data'
 
+// BASE_URL is set from vue.config.js publicPath
+export const APP_PATH = process.env.BASE_URL
+
 export default {
   /**
-   * fetch config from API
+   * fetch config from config map
    */
   async fetchConfig(): Promise<Config> {
 
-    // TODO -- follow the lear example ...
-    // const origin = window.location.origin
-    // const vueAppPath = process.env.VUE_APP_PATH
-    // const vueAppAuthPath = process.env.VUE_APP_AUTH_PATH
-    //
-    // if (!vueAppPath || !vueAppAuthPath) {
-    //   throw new Error('failed to get env variables')
-    // }
-    //
-    // const baseUrl = `${origin}/${vueAppPath}/`
-    // sessionStorage.setItem('BASE_URL', baseUrl)
-    //
-    // const authUrl = `${origin}/${vueAppAuthPath}/`
-    // sessionStorage.setItem('AUTH_URL', authUrl)
-    //
-    // const url = `/${vueAppPath}/config/configuration.json`
-    // end of to do
-
-    // remove next line once above to do is done
-    const url = '/config/configuration.json'
-
+    const url = `${APP_PATH}config/configuration.json`
     const headers = {
       'Accept': 'application/json',
       'ResponseType': 'application/json',
       'Cache-Control': 'no-cache'
     }
+    // console.log('Retrieve configuration from url:', url)
     const response = await axiosAuth.get(url, {headers})
 
-    // with the above to do workaround the response data is a string and needs to be parse.
-    // it is expected that once we do the to do above the response data with be an object
     const rd: object = response.data
     const cf: object = (typeof rd === 'string') ? JSON.parse(rd) : rd
     AppData.resetConfig(cf)

--- a/ppr-ui/src/utils/config-helper.ts
+++ b/ppr-ui/src/utils/config-helper.ts
@@ -16,7 +16,6 @@ export default {
       'ResponseType': 'application/json',
       'Cache-Control': 'no-cache'
     }
-    // console.log('Retrieve configuration from url:', url)
     const response = await axiosAuth.get(url, {headers})
 
     const rd: object = response.data

--- a/ppr-ui/vue.config.js
+++ b/ppr-ui/vue.config.js
@@ -1,3 +1,9 @@
+
+// For local development set the APP_PATH environment variable to '/'
+// or use  'npm run serve'  (package.json)
+const APP_PATH = process.env.APP_PATH || '/cooperatives/ppr'
+console.log('Start Vue build (vue.config.js) with APP_PATH', APP_PATH)
+
 module.exports = {
   lintOnSave: false,
   configureWebpack: {
@@ -7,8 +13,12 @@ module.exports = {
     optimization: {
       splitChunks: {
         minSize: 100000,
-        maxSize: 2500000
+        maxSize: 2500000,
+        // automaticNameDelimiter added to workaround problem with WAM
+        // see https://github.com/bcgov/ppr/issues/270
+        automaticNameDelimiter: "-"
       }
     }
-  }
+  },
+  publicPath: APP_PATH
 }

--- a/ppr-ui/vue.config.js
+++ b/ppr-ui/vue.config.js
@@ -2,7 +2,7 @@
 // For local development set the APP_PATH environment variable to '/'
 // or use  'npm run serve'  (package.json)
 const APP_PATH = process.env.APP_PATH || '/cooperatives/ppr'
-console.log('Start Vue build (vue.config.js) with APP_PATH', APP_PATH)
+console.info('Start Vue build (vue.config.js) with APP_PATH', APP_PATH)
 
 module.exports = {
   lintOnSave: false,


### PR DESCRIPTION
To get here we need to make several adjustments in many different locations. This commit strives to reduce the number of moving parts to one environment variable that is pushed into the build configurations and then into the running environment. This variable is used by vue.config.js which provides it to the application BASE_URL which shares it with the rest of the application.

As well this commit provides a standard way to process and apply the build and deploy configs.  This standardizes our default configuration (just run the process.sh script) and allows for experimentation (e.g. load from a private repo branch and create new openshift resources that don't touch our running app) and for a rapid change to a new domain or subpath (we expect to change from /cooperatives/ppr to /ppr sometime in the near term).