### PR TITLE
Post search endpoint

### DIFF
--- a/ppr-api/src/endpoints/search.py
+++ b/ppr-api/src/endpoints/search.py
@@ -4,7 +4,7 @@ import json
 
 import fastapi
 import requests
-from starlette import responses
+from starlette import responses, status
 
 import config
 import schemas.search
@@ -43,3 +43,12 @@ def read_search(search_id: int, search_repository: repository.search_repository.
     if search_db_row is None:
         raise fastapi.HTTPException(status_code=404, detail="Search record not found")
     return search_db_row
+
+
+@router.post("/searches", response_model=schemas.search.Search, response_model_by_alias=False)
+def create_search(response: responses.Response, search_input: schemas.search.SearchBase,
+                  search_repository: repository.search_repository.SearchRepository = fastapi.Depends()):
+    # TODO execute the search query and create search_result records. See https://github.com/bcgov/ppr/issues/222
+    search_model = search_repository.create_search(search_input)
+    response.status_code = status.HTTP_201_CREATED
+    return search_model

--- a/ppr-api/src/endpoints/search.py
+++ b/ppr-api/src/endpoints/search.py
@@ -14,7 +14,7 @@ router = fastapi.APIRouter()
 
 
 # TODO: read the ims-api endpoint from an environment variable.
-@router.get("/search")
+@router.get('/search')
 async def search(serial: str, response: responses.Response):
     """
     Find financial statements that match the search criteria.
@@ -22,14 +22,14 @@ async def search(serial: str, response: responses.Response):
         Parameters:
             serial: The serial number to search for.
     """
-    ims_response = requests.get(config.IMS_API_URL + "/search?serial={}".format(serial))
+    ims_response = requests.get(config.IMS_API_URL + '/search?serial={}'.format(serial))
 
     response.status_code = ims_response.status_code
 
-    return json.loads(ims_response.content.decode("utf-8"))
+    return json.loads(ims_response.content.decode('utf-8'))
 
 
-@router.get("/searches/{search_id}", response_model=schemas.search.Search, response_model_by_alias=False)
+@router.get('/searches/{search_id}', response_model=schemas.search.Search, response_model_by_alias=False)
 def read_search(search_id: int, search_repository: repository.search_repository.SearchRepository = fastapi.Depends()):
     """
     Get the details for a previously submitted search request
@@ -41,11 +41,11 @@ def read_search(search_id: int, search_repository: repository.search_repository.
     """
     search_db_row = search_repository.get_search(search_id)
     if search_db_row is None:
-        raise fastapi.HTTPException(status_code=404, detail="Search record not found")
+        raise fastapi.HTTPException(status_code=404, detail='Search record not found')
     return search_db_row
 
 
-@router.post("/searches", response_model=schemas.search.Search, response_model_by_alias=False)
+@router.post('/searches', response_model=schemas.search.Search, response_model_by_alias=False)
 def create_search(response: responses.Response, search_input: schemas.search.SearchBase,
                   search_repository: repository.search_repository.SearchRepository = fastapi.Depends()):
     # TODO execute the search query and create search_result records. See https://github.com/bcgov/ppr/issues/222

--- a/ppr-api/src/models/edb.py
+++ b/ppr-api/src/models/edb.py
@@ -25,5 +25,9 @@ def get_session():
     db = SessionLocal()
     try:
         yield db
+        db.commit()
+    except Exception as ex:
+        db.rollback()
+        raise ex
     finally:
         db.close()

--- a/ppr-api/src/models/patroni.py
+++ b/ppr-api/src/models/patroni.py
@@ -25,5 +25,9 @@ def get_session():
     db = SessionLocal()
     try:
         yield db
+        db.commit()
+    except Exception as ex:
+        db.rollback()
+        raise ex
     finally:
         db.close()

--- a/ppr-api/src/repository/search_repository.py
+++ b/ppr-api/src/repository/search_repository.py
@@ -2,6 +2,7 @@ import fastapi
 import sqlalchemy.orm
 
 import models.search
+import schemas.search
 
 
 class SearchRepository:
@@ -9,6 +10,13 @@ class SearchRepository:
 
     def __init__(self, session: sqlalchemy.orm.Session = fastapi.Depends(models.database.get_session)):
         self.db = session
+
+    def create_search(self, search_input: schemas.search.SearchBase):
+        model = models.search.Search(criteria=search_input.criteria, type_code=search_input.type)
+        self.db.add(model)
+        self.db.flush()
+        self.db.refresh(model)
+        return model
 
     def get_search(self, search_id: int):
         return self.db.query(models.search.Search).filter(models.search.Search.id == search_id).first()

--- a/ppr-api/src/schemas/search.py
+++ b/ppr-api/src/schemas/search.py
@@ -18,7 +18,7 @@ class SearchBase(pydantic.BaseModel):
     criteria: dict
 
     @pydantic.validator('type')
-    def type_must_match_search_type(cls, search_type):
+    def type_must_match_search_type(cls, search_type):  # pylint:disable=no-self-argument
         try:
             SearchType[search_type]
         except KeyError:
@@ -26,7 +26,7 @@ class SearchBase(pydantic.BaseModel):
         return search_type
 
     @pydantic.validator('criteria')
-    def criteria_must_match_format_for_type(cls, criteria, values):
+    def criteria_must_match_format_for_type(cls, criteria, values):  # pylint:disable=no-self-argument
         if 'type' not in values:
             return criteria
 

--- a/ppr-api/tests/integration/api/test_search.py
+++ b/ppr-api/tests/integration/api/test_search.py
@@ -8,18 +8,37 @@ client = TestClient(main.app)
 
 
 def test_read_search():
-    search_rec = create_user("REGISTRATION_NUMBER", {'value': '1234'})
+    search_rec = create_test_search_record('REGISTRATION_NUMBER', {'value': '1234567'})
 
     rv = client.get('/searches/{}'.format(search_rec.id))
     assert rv.status_code == 200
     search = rv.json()
     assert search['id'] == search_rec.id
-    assert search['type'] == "REGISTRATION_NUMBER"
-    assert search['criteria'] == {'value': '1234'}
-    assert search['searchDateTime'] == search_rec.creation_date_time.isoformat(timespec="seconds")
+    assert search['type'] == 'REGISTRATION_NUMBER'
+    assert search['criteria'] == {'value': '1234567'}
+    assert search['searchDateTime'] == search_rec.creation_date_time.isoformat(timespec='seconds')
 
 
-def create_user(type_code: str, criteria: dict):
+def test_create_registration_number_search():
+    search_input = {'type': 'REGISTRATION_NUMBER', 'criteria': {'value': '987654Z'}}
+
+    rv = client.post('/searches', json=search_input)
+
+    assert rv.status_code == 201
+    body = rv.json()
+    assert body['type'] == 'REGISTRATION_NUMBER'
+    assert body['criteria'] == {'value': '987654Z'}
+    result_id = body['id']
+    assert result_id > 0
+
+    stored = retrieve_search_record(result_id)
+    assert stored
+    assert stored.type_code == 'REGISTRATION_NUMBER'
+    assert stored.criteria == {'value': '987654Z'}
+    assert body['searchDateTime'] == stored.creation_date_time.isoformat(timespec='seconds')
+
+
+def create_test_search_record(type_code: str, criteria: dict):
     db = models.database.SessionLocal()
     try:
         search_rec = models.search.Search(type_code=type_code, criteria=criteria)
@@ -27,5 +46,13 @@ def create_user(type_code: str, criteria: dict):
         db.commit()
         db.refresh(search_rec)
         return search_rec
+    finally:
+        db.close()
+
+
+def retrieve_search_record(search_id: int):
+    db = models.database.SessionLocal()
+    try:
+        return db.query(models.search.Search).filter(models.search.Search.id == search_id).first()
     finally:
         db.close()

--- a/ppr-api/tests/unit/schemas/test_search_schema.py
+++ b/ppr-api/tests/unit/schemas/test_search_schema.py
@@ -1,0 +1,61 @@
+import pytest
+
+import schemas.search
+
+
+def test_validate_criteria_no_value_with_regnum():
+    try:
+        schemas.search.SearchBase(criteria={}, type=schemas.search.SearchType.REGISTRATION_NUMBER.name)
+    except ValueError:
+        pass
+    else:
+        pytest.fail("A validation error was expected since there was no value field in the criteria")
+
+
+def test_validate_criteria_when_value_not_alphanumeric_regnum():
+    try:
+        schemas.search.SearchBase(criteria={'value': '123_56A'},
+                                  type=schemas.search.SearchType.REGISTRATION_NUMBER.name)
+    except ValueError:
+        pass
+    else:
+        pytest.fail("A validation error was expected since the registration number has an invalid format")
+
+
+def test_validate_criteria_when_value_not_alphanumeric_regnum():
+    try:
+        schemas.search.SearchBase(criteria={'value': '1234567A'},
+                                  type=schemas.search.SearchType.REGISTRATION_NUMBER.name)
+    except ValueError:
+        pass
+    else:
+        pytest.fail("A validation error was expected since the registration number was an invalid length")
+
+
+def test_validate_criteria_when_valid_with_regnum():
+    search = schemas.search.SearchBase(criteria={'value': '123456A'},
+                                       type=schemas.search.SearchType.REGISTRATION_NUMBER.name)
+    assert search.criteria == {'value': '123456A'}
+
+
+def test_validate_type_when_invalid():
+    try:
+        schemas.search.SearchBase(type='INVALID_ENUM', criteria={'value': '1234567'})
+    except ValueError:
+        pass
+    else:
+        pytest.fail("A validation error was expected since type was invalid")
+
+
+def test_validate_type_when_valid_enum_name():
+    search = schemas.search.SearchBase(type=schemas.search.SearchType.AIRCRAFT_DOT.name, criteria={'value': '1234567'})
+    assert search.type == schemas.search.SearchType.AIRCRAFT_DOT.name
+
+
+def test_validate_when_type_invalid_and_criteria_empty():
+    try:
+        search = schemas.search.SearchBase(type='INVALID_ENUM', criteria={})
+    except ValueError:
+        pass
+    else:
+        pytest.fail("A validation error was expected since the input was invalid")

--- a/ppr-api/tests/unit/schemas/test_search_schema.py
+++ b/ppr-api/tests/unit/schemas/test_search_schema.py
@@ -9,7 +9,7 @@ def test_validate_criteria_no_value_with_regnum():
     except ValueError:
         pass
     else:
-        pytest.fail("A validation error was expected since there was no value field in the criteria")
+        pytest.fail('A validation error was expected since there was no value field in the criteria')
 
 
 def test_validate_criteria_when_value_not_alphanumeric_regnum():
@@ -19,7 +19,7 @@ def test_validate_criteria_when_value_not_alphanumeric_regnum():
     except ValueError:
         pass
     else:
-        pytest.fail("A validation error was expected since the registration number has an invalid format")
+        pytest.fail('A validation error was expected since the registration number has an invalid format')
 
 
 def test_validate_criteria_when_value_not_alphanumeric_regnum():
@@ -29,7 +29,7 @@ def test_validate_criteria_when_value_not_alphanumeric_regnum():
     except ValueError:
         pass
     else:
-        pytest.fail("A validation error was expected since the registration number was an invalid length")
+        pytest.fail('A validation error was expected since the registration number was an invalid length')
 
 
 def test_validate_criteria_when_valid_with_regnum():
@@ -44,7 +44,7 @@ def test_validate_type_when_invalid():
     except ValueError:
         pass
     else:
-        pytest.fail("A validation error was expected since type was invalid")
+        pytest.fail('A validation error was expected since type was invalid')
 
 
 def test_validate_type_when_valid_enum_name():
@@ -58,4 +58,4 @@ def test_validate_when_type_invalid_and_criteria_empty():
     except ValueError:
         pass
     else:
-        pytest.fail("A validation error was expected since the input was invalid")
+        pytest.fail('A validation error was expected since the input was invalid')


### PR DESCRIPTION
Created an end-point to handle a POST requests to `/searches`.  This included a few changes including:
- The new "POST" method in the end point
- Addition of commit/rollback around the database dependency
- Implementation of pydantic validators in the schema. Ran into one odd-ball issue here:
  - The validator should act like a class method and doesn't require self.  pylint worked fine on my machine, but failed in Github Actions: https://github.com/vituary-solutions/ppr/runs/399781757
  - To work around this for now, I've added hints for pylint to ignore it
- Updates to the model and repository for creating database objects
- unit and integration tests