### PR TITLE
Add an endpoint for search results that returns dummy data

### DIFF
--- a/ppr-api/src/endpoints/search.py
+++ b/ppr-api/src/endpoints/search.py
@@ -1,12 +1,15 @@
 """ Define the endpoints for searching. """
 
+import datetime
 import json
+import typing
 
 import fastapi
 import requests
 from starlette import responses, status
 
 import config
+import schemas.financing_statement
 import schemas.search
 import repository.search_repository
 
@@ -52,3 +55,24 @@ def create_search(response: responses.Response, search_input: schemas.search.Sea
     search_model = search_repository.create_search(search_input)
     response.status_code = status.HTTP_201_CREATED
     return search_model
+
+
+@router.get('/searches/{search_id}/results', response_model=typing.List[schemas.search.SearchResult],
+            response_model_by_alias=False)
+def read_search_results(search_id: int,
+                        search_repository: repository.search_repository.SearchRepository = fastapi.Depends()):
+    """
+    List the results for the provided search
+
+        Parameters:
+            search_id: The identifier of the search instance to lookup
+        Returns:
+            typing.List[schemas.search.SearchResult]
+    """
+    # TODO Showing dummy data for the moment, complete as the data model fills out. Issue #222.
+    fin_stmt = schemas.financing_statement.FinancingStatement(
+        baseRegistrationNumber='123456A', documentId='B9876543', registrationDateTime=datetime.datetime.now(),
+        type='SECURITY_AGREEMENT', registeringParty={}, securedParties=[], debtors=[], vehicleCollateral=[],
+        generalCollateral=[], expiryDate=datetime.date.today()
+    )
+    return [schemas.search.SearchResult(type='EXACT', financingStatement=fin_stmt)]

--- a/ppr-api/src/schemas/financing_statement.py
+++ b/ppr-api/src/schemas/financing_statement.py
@@ -1,0 +1,25 @@
+import datetime
+import typing
+
+from pydantic import BaseModel
+
+
+class FinancingStatementBase(BaseModel):
+    type: str
+    registeringParty: dict
+    securedParties: typing.List[dict]
+    debtors: typing.List[dict]
+    vehicleCollateral: typing.List[dict]
+    generalCollateral: typing.List[dict]
+    expiryDate: datetime.date
+
+
+class FinancingStatement(FinancingStatementBase):
+    baseRegistrationNumber: str
+    documentId: str
+    registrationDateTime: datetime.datetime
+
+    class Config:
+        json_encoders = {
+            datetime.datetime: lambda dt: dt.isoformat(timespec='seconds')
+        }

--- a/ppr-api/src/schemas/search.py
+++ b/ppr-api/src/schemas/search.py
@@ -3,6 +3,8 @@ import enum
 
 import pydantic
 
+import schemas.financing_statement
+
 
 class SearchType(enum.Enum):
     AIRCRAFT_DOT = 'AIRCRAFT_DOT'
@@ -60,3 +62,8 @@ class Search(SearchBase):
         json_encoders = {
             datetime.datetime: lambda dt: dt.isoformat(timespec='seconds')
         }
+
+
+class SearchResult(pydantic.BaseModel):
+    type: str
+    financingStatement: schemas.financing_statement.FinancingStatement


### PR DESCRIPTION
Create the basic structure for `GET /searches/{id}/results` and add a reachable endpoint.  For the moment it contains dummy data, but will have it query the db in future commits