### PR TITLE
On a GET for search results, pull search results from the database.

### DIFF
--- a/ppr-api/src/schemas/financing_statement.py
+++ b/ppr-api/src/schemas/financing_statement.py
@@ -1,7 +1,13 @@
 import datetime
+import enum
 import typing
 
 from pydantic import BaseModel
+
+
+class RegistrationType(enum.Enum):
+    SECURITY_AGREEMENT = 'SECURITY_AGREEMENT'
+    REPAIRERS_LIEN = 'REPAIRERS_LIEN'
 
 
 class FinancingStatementBase(BaseModel):
@@ -11,7 +17,7 @@ class FinancingStatementBase(BaseModel):
     debtors: typing.List[dict]
     vehicleCollateral: typing.List[dict]
     generalCollateral: typing.List[dict]
-    expiryDate: datetime.date
+    expiryDate: datetime.date = None
 
 
 class FinancingStatement(FinancingStatementBase):

--- a/ppr-api/src/schemas/search.py
+++ b/ppr-api/src/schemas/search.py
@@ -15,6 +15,11 @@ class SearchType(enum.Enum):
     SERIAL_NUMBER = 'SERIAL_NUMBER'
 
 
+class SearchResultType(enum.Enum):
+    EXACT = True
+    SIMILAR = False
+
+
 class SearchBase(pydantic.BaseModel):
     type: str
     criteria: dict
@@ -66,4 +71,12 @@ class Search(SearchBase):
 
 class SearchResult(pydantic.BaseModel):
     type: str
-    financingStatement: schemas.financing_statement.FinancingStatement
+    financingStatement: schemas.financing_statement.FinancingStatement = None
+
+    @pydantic.validator('type')
+    def type_must_match_search_result_type(cls, value):  # pylint:disable=no-self-argument
+        try:
+            SearchResultType[value]
+        except KeyError:
+            raise ValueError('type must be one of: {}'.format(list(map(lambda st: st.name, SearchResultType))))
+        return value

--- a/ppr-api/tests/unit/endpoints/test_search.py
+++ b/ppr-api/tests/unit/endpoints/test_search.py
@@ -26,6 +26,44 @@ def test_read_search_not_found():
         pytest.fail('A Not Found error was expected')
 
 
+def test_read_search_results_not_found():
+    repo = MockSearchRepository(None)
+    try:
+        endpoints.search.read_search_results(27, repo)
+    except fastapi.HTTPException as ex:
+        assert ex.status_code == 404
+    else:
+        pytest.fail('A Not Found error was expected')
+
+
+def test_read_search_results_is_empty():
+    search_record = models.search.Search(results=[])
+    repo = MockSearchRepository(search_record)
+
+    results = endpoints.search.read_search_results(27, repo)
+    assert results == []
+
+
+def test_read_search_results_has_exact_match():
+    search_record = models.search.Search(results=[models.search.SearchResult(exact=True, selected=True,
+                                                                             registration_number='123456A')])
+    repo = MockSearchRepository(search_record)
+
+    results = endpoints.search.read_search_results(27, repo)
+    assert len(results) == 1
+    assert results[0].type == 'EXACT'
+
+
+def test_read_search_results_has_inexact_match():
+    search_record = models.search.Search(results=[models.search.SearchResult(exact=False, selected=True,
+                                                                             registration_number='123456A')])
+    repo = MockSearchRepository(search_record)
+
+    results = endpoints.search.read_search_results(27, repo)
+    assert len(results) == 1
+    assert results[0].type == 'SIMILAR'
+
+
 class MockSearchRepository:
     def __init__(self, search_result):
         self.search = search_result

--- a/ppr-api/tests/unit/schemas/test_search_schema.py
+++ b/ppr-api/tests/unit/schemas/test_search_schema.py
@@ -3,7 +3,7 @@ import pytest
 import schemas.search
 
 
-def test_validate_criteria_no_value_with_regnum():
+def test_search_base_validate_criteria_no_value_with_regnum():
     try:
         schemas.search.SearchBase(criteria={}, type=schemas.search.SearchType.REGISTRATION_NUMBER.name)
     except ValueError:
@@ -12,7 +12,7 @@ def test_validate_criteria_no_value_with_regnum():
         pytest.fail('A validation error was expected since there was no value field in the criteria')
 
 
-def test_validate_criteria_when_value_not_alphanumeric_regnum():
+def test_search_base_validate_criteria_when_value_not_alphanumeric_regnum():
     try:
         schemas.search.SearchBase(criteria={'value': '123_56A'},
                                   type=schemas.search.SearchType.REGISTRATION_NUMBER.name)
@@ -22,23 +22,13 @@ def test_validate_criteria_when_value_not_alphanumeric_regnum():
         pytest.fail('A validation error was expected since the registration number has an invalid format')
 
 
-def test_validate_criteria_when_value_not_alphanumeric_regnum():
-    try:
-        schemas.search.SearchBase(criteria={'value': '1234567A'},
-                                  type=schemas.search.SearchType.REGISTRATION_NUMBER.name)
-    except ValueError:
-        pass
-    else:
-        pytest.fail('A validation error was expected since the registration number was an invalid length')
-
-
-def test_validate_criteria_when_valid_with_regnum():
+def test_search_base_validate_criteria_when_valid_with_regnum():
     search = schemas.search.SearchBase(criteria={'value': '123456A'},
                                        type=schemas.search.SearchType.REGISTRATION_NUMBER.name)
     assert search.criteria == {'value': '123456A'}
 
 
-def test_validate_type_when_invalid():
+def test_search_base_validate_type_when_invalid():
     try:
         schemas.search.SearchBase(type='INVALID_ENUM', criteria={'value': '1234567'})
     except ValueError:
@@ -47,15 +37,29 @@ def test_validate_type_when_invalid():
         pytest.fail('A validation error was expected since type was invalid')
 
 
-def test_validate_type_when_valid_enum_name():
+def test_search_base_validate_type_when_valid_enum_name():
     search = schemas.search.SearchBase(type=schemas.search.SearchType.AIRCRAFT_DOT.name, criteria={'value': '1234567'})
     assert search.type == schemas.search.SearchType.AIRCRAFT_DOT.name
 
 
-def test_validate_when_type_invalid_and_criteria_empty():
+def test_search_base_validate_when_type_invalid_and_criteria_empty():
     try:
-        search = schemas.search.SearchBase(type='INVALID_ENUM', criteria={})
+        schemas.search.SearchBase(type='INVALID_ENUM', criteria={})
     except ValueError:
         pass
     else:
         pytest.fail('A validation error was expected since the input was invalid')
+
+
+def test_search_result_validate_type_when_exact():
+    search = schemas.search.SearchResult(type='EXACT', financingStatement=None)
+    assert search.type == schemas.search.SearchResultType.EXACT.name
+
+
+def test_search_result_validate_type_when_invalid():
+    try:
+        schemas.search.SearchResult(type='INVALID_ENUM_NAME', financingStatement=None)
+    except ValueError:
+        pass
+    else:
+        pytest.fail('A validation error was expected since type was invalid')


### PR DESCRIPTION
The saved 'exact' value will now be used, though the financing statement is still a faked up stub.