### PR TITLE
Api search by registration number

### DIFF
--- a/ppr-api/migrations/versions/947ffeeeda60_create_foreign_key_relationship_between_.py
+++ b/ppr-api/migrations/versions/947ffeeeda60_create_foreign_key_relationship_between_.py
@@ -1,0 +1,28 @@
+"""Create foreign key relationship between search_result and registration
+
+Revision ID: 947ffeeeda60
+Revises: 1461b03c20de
+Create Date: 2020-01-24 16:07:20.288676
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '947ffeeeda60'
+down_revision = 'fc3c53132a9b'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Remove orphaned search_result rows (don't not have a valid registration_number)
+    op.execute('DELETE FROM search_result sr WHERE NOT EXISTS '
+               '(SELECT 1 FROM registration r WHERE r.reg_number = sr.registration_number)')
+
+    op.create_foreign_key('search_result_registration_fk', 'search_result', 'registration', ['registration_number'],
+                          ['reg_number'])
+
+
+def downgrade():
+    op.drop_constraint('search_result_registration_fk', 'search_result')

--- a/ppr-api/migrations/versions/fc3c53132a9b_create_financing_statement_document_tables.py
+++ b/ppr-api/migrations/versions/fc3c53132a9b_create_financing_statement_document_tables.py
@@ -49,14 +49,18 @@ def upgrade():
         sa.Column('change_type_cd', sa.CHAR(length=2), sa.ForeignKey('registration_change_type.change_type_cd'),
                   nullable=True),
         sa.Column('reg_date', sa.DateTime, server_default=sa.text('NOW()'), nullable=False),
-        sa.Column('life', sa.Integer, nullable=False),
+        sa.Column('life', sa.Integer),
         sa.Column('crown_charge_act', sa.CHAR(length=2), sa.ForeignKey('crown_charge_type.crown_charge_type_cd')),
         sa.Column('crown_charge_other', sa.String(length=70)),
         sa.Column('description', postgresql.TEXT),
-        sa.Column('document_number', sa.CHAR(length=8), nullable=False),
+        sa.Column('document_number', sa.CHAR(length=8)),
         sa.Column('ims_billing_number', sa.String(length=8)),
         sa.Column('ims_user_id', sa.String(length=32))
     )
+
+    # Resize search_result.registration_number to match registration.reg_number
+    op.alter_column('search_result', 'registration_number', existing_type=sa.String(length=7),
+                    type_=sa.String(length=10), existing_nullable=False, nullable=False)
 
 
 def downgrade():

--- a/ppr-api/src/models/financing_statement.py
+++ b/ppr-api/src/models/financing_statement.py
@@ -14,7 +14,7 @@ class FinancingStatement(BaseORM):
     life_in_years = sqlalchemy.Column('life', sqlalchemy.Integer)
     expiry_date = sqlalchemy.Column(sqlalchemy.Date)
     discharged = sqlalchemy.Column(sqlalchemy.BOOLEAN)
-    last_updated = sqlalchemy.Column('last_update_timestamp', sqlalchemy.DateTime)
+    last_updated = sqlalchemy.Column('last_update_timestamp', sqlalchemy.DateTime, onupdate=sqlalchemy.func.now())
     user_id = sqlalchemy.Column(sqlalchemy.String(length=8))
 
     events = sqlalchemy.orm.relationship('FinancingStatementEvent', back_populates='base_registration')
@@ -27,8 +27,7 @@ class FinancingStatementEvent(BaseORM):
     base_registration_number = sqlalchemy.Column('base_reg_number', sqlalchemy.String(length=10),
                                                  sqlalchemy.ForeignKey('financing_statement.reg_number'))
     change_type_code = sqlalchemy.Column('change_type_cd', sqlalchemy.CHAR(length=2))
-    registration_date = sqlalchemy.Column('reg_date', sqlalchemy.DateTime)
-    life_in_years = sqlalchemy.Column('life', sqlalchemy.Integer)
+    registration_date = sqlalchemy.Column('reg_date', sqlalchemy.DateTime, server_default=sqlalchemy.func.now())
     description = sqlalchemy.Column(postgresql.TEXT)
     document_number = sqlalchemy.Column(sqlalchemy.String(length=8))
 

--- a/ppr-api/src/models/financing_statement.py
+++ b/ppr-api/src/models/financing_statement.py
@@ -1,0 +1,35 @@
+import sqlalchemy
+from sqlalchemy.dialects import postgresql
+import sqlalchemy.orm
+
+from .database import BaseORM
+
+
+class FinancingStatement(BaseORM):
+    __tablename__ = 'financing_statement'
+
+    registration_number = sqlalchemy.Column('reg_number', sqlalchemy.String(length=10), primary_key=True)
+    registration_type_code = sqlalchemy.Column('reg_type_cd', sqlalchemy.CHAR(length=2))
+    status = sqlalchemy.Column(sqlalchemy.CHAR(length=1))
+    life_in_years = sqlalchemy.Column('life', sqlalchemy.Integer)
+    expiry_date = sqlalchemy.Column(sqlalchemy.Date)
+    discharged = sqlalchemy.Column(sqlalchemy.BOOLEAN)
+    last_updated = sqlalchemy.Column('last_update_timestamp', sqlalchemy.DateTime)
+    user_id = sqlalchemy.Column(sqlalchemy.String(length=8))
+
+    events = sqlalchemy.orm.relationship('FinancingStatementEvent', back_populates='base_registration')
+
+
+class FinancingStatementEvent(BaseORM):
+    __tablename__ = 'registration'
+
+    registration_number = sqlalchemy.Column('reg_number', sqlalchemy.String(length=10), primary_key=True)
+    base_registration_number = sqlalchemy.Column('base_reg_number', sqlalchemy.String(length=10),
+                                                 sqlalchemy.ForeignKey('financing_statement.reg_number'))
+    change_type_code = sqlalchemy.Column('change_type_cd', sqlalchemy.CHAR(length=2))
+    registration_date = sqlalchemy.Column('reg_date', sqlalchemy.DateTime)
+    life_in_years = sqlalchemy.Column('life', sqlalchemy.Integer)
+    description = sqlalchemy.Column(postgresql.TEXT)
+    document_number = sqlalchemy.Column(sqlalchemy.String(length=8))
+
+    base_registration = sqlalchemy.orm.relationship('FinancingStatement', back_populates='events')

--- a/ppr-api/src/models/search.py
+++ b/ppr-api/src/models/search.py
@@ -20,8 +20,10 @@ class SearchResult(BaseORM):
     __tablename__ = 'search_result'
 
     search_id = sqlalchemy.Column(sqlalchemy.BigInteger, sqlalchemy.ForeignKey('search.id'), primary_key=True)
-    registration_number = sqlalchemy.Column(sqlalchemy.String(length=7), primary_key=True)
+    registration_number = sqlalchemy.Column(sqlalchemy.String(length=7),
+                                            sqlalchemy.ForeignKey('registration.reg_number'), primary_key=True)
     exact = sqlalchemy.Column(sqlalchemy.BOOLEAN)
     selected = sqlalchemy.Column(sqlalchemy.BOOLEAN)
 
     search = sqlalchemy.orm.relationship('Search', back_populates='results')
+    financing_statement_event = sqlalchemy.orm.relationship('FinancingStatementEvent')

--- a/ppr-api/src/repository/financing_statement_repository.py
+++ b/ppr-api/src/repository/financing_statement_repository.py
@@ -1,0 +1,16 @@
+import fastapi
+import sqlalchemy.orm
+
+import models.financing_statement
+
+
+class FinancingStatementRepository:
+    db: sqlalchemy.orm.Session
+
+    def __init__(self, session: sqlalchemy.orm.Session = fastapi.Depends(models.database.get_session)):
+        self.db = session
+
+    def find_event_by_registration_number(self, registration_number: str):
+        return self.db.query(models.financing_statement.FinancingStatementEvent)\
+            .filter(models.financing_statement.FinancingStatementEvent.registration_number.ilike(registration_number))\
+            .first()

--- a/ppr-api/src/schemas/financing_statement.py
+++ b/ppr-api/src/schemas/financing_statement.py
@@ -22,7 +22,7 @@ class FinancingStatementBase(BaseModel):
 
 class FinancingStatement(FinancingStatementBase):
     baseRegistrationNumber: str
-    documentId: str
+    documentId: str = None
     registrationDateTime: datetime.datetime
 
     class Config:

--- a/ppr-api/src/schemas/financing_statement.py
+++ b/ppr-api/src/schemas/financing_statement.py
@@ -6,8 +6,8 @@ from pydantic import BaseModel
 
 
 class RegistrationType(enum.Enum):
-    SECURITY_AGREEMENT = 'SECURITY_AGREEMENT'
-    REPAIRERS_LIEN = 'REPAIRERS_LIEN'
+    SECURITY_AGREEMENT = 'SA'
+    REPAIRERS_LIEN = 'RL'
 
 
 class FinancingStatementBase(BaseModel):

--- a/ppr-api/src/schemas/search.py
+++ b/ppr-api/src/schemas/search.py
@@ -42,8 +42,6 @@ class SearchBase(pydantic.BaseModel):
                 raise ValueError('"value" is required in criteria')
             if not criteria['value'].isalnum():
                 raise ValueError('"value" must be alphanumeric')
-            if len(criteria['value']) != 7:
-                raise ValueError('"value" must be 7 characters')
         return criteria
 
     class Config:

--- a/ppr-api/tests/unit/endpoints/test_search.py
+++ b/ppr-api/tests/unit/endpoints/test_search.py
@@ -4,6 +4,7 @@ import fastapi
 import pytest
 
 import endpoints.search
+import models.financing_statement
 import models.search
 
 
@@ -45,8 +46,10 @@ def test_read_search_results_is_empty():
 
 
 def test_read_search_results_has_exact_match():
+    stub_fin_stmt = stub_financing_statement_event('123456A')
     search_record = models.search.Search(results=[models.search.SearchResult(exact=True, selected=True,
-                                                                             registration_number='123456A')])
+                                                                             registration_number='123456A',
+                                                                             financing_statement_event=stub_fin_stmt)])
     repo = MockSearchRepository(search_record)
 
     results = endpoints.search.read_search_results(27, repo)
@@ -55,13 +58,24 @@ def test_read_search_results_has_exact_match():
 
 
 def test_read_search_results_has_inexact_match():
+    stub_fin_stmt = stub_financing_statement_event('123456A')
     search_record = models.search.Search(results=[models.search.SearchResult(exact=False, selected=True,
-                                                                             registration_number='123456A')])
+                                                                             registration_number='123456A',
+                                                                             financing_statement_event=stub_fin_stmt)])
     repo = MockSearchRepository(search_record)
 
     results = endpoints.search.read_search_results(27, repo)
     assert len(results) == 1
     assert results[0].type == 'SIMILAR'
+
+
+def stub_financing_statement_event(reg_number: str):
+    return models.financing_statement.FinancingStatementEvent(
+        registration_number=reg_number, base_registration_number=reg_number, document_number='A1234567',
+        registration_date=datetime.datetime.now(), base_registration=models.financing_statement.FinancingStatement(
+            registration_number='123456A', registration_type_code='SA'
+        )
+    )
 
 
 class MockSearchRepository:


### PR DESCRIPTION
Update registration number searches to run against the registrations.  This includes changes to:
- Read data from the tables in the database
- A migration script that creates a foreign key relationship between search_result and registration
- Updates to previous migrations to provide some more leniency and clean up column types
- Updates to existing tests to make them passing