### PR TITLE
Added serial number search feature flag

### DIFF
--- a/ppr-ui/src/flags/ld-client.ts
+++ b/ppr-ui/src/flags/ld-client.ts
@@ -30,8 +30,8 @@ class VueLdClient {
   private updateFlags(allFlags: LDFlagSet): void {
     const flags = FeatureFlags.Instance
     console.debug('LDFlags on change flags', allFlags)
-    flags.feature1 = allFlags['search-document-registration-number']
-    flags.feature2 = allFlags['poc-feature-2']
+    flags.feature1 = allFlags['search-registration-number']
+    flags.feature2 = allFlags['search-serial-number']
   }
 
   // changeUserContext(userKey: string) {

--- a/ppr-ui/src/views/Home.vue
+++ b/ppr-ui/src/views/Home.vue
@@ -82,7 +82,8 @@ export default createComponent({
     const userIsAuthed = computed((): boolean => !!sessionStorage.getItem('KEYCLOAK_TOKEN'))
 
     // Feature Flag
-    const userCanSearch = computed((): boolean => useFeatureFlags().feature1 && userIsAuthed.value)
+    const userCanSearch = computed((): boolean => (useFeatureFlags().feature1 || useFeatureFlags().feature2) &&
+      userIsAuthed.value)
 
     function goSearch(): void {
       router.push('search')


### PR DESCRIPTION
Added the Feature Flag for the serial number search - this is to hide the search functionality that is not part of this sprint. We'll have to do that in the SearchPage component once it is done.

While I was in the file also changed the flag `search-document-registration-number` to `search-registration-number`.