### PR TITLE
Add an authentication module which calls the Auth API with the provided token

### DIFF
--- a/ppr-api/docs/dotenv_template
+++ b/ppr-api/docs/dotenv_template
@@ -11,6 +11,8 @@
 #
 PPR_API_IMS_API_URL=http://localhost:8888
 
+PPR_API_AUTH_API_URL=https://auth-api.hostname/api/v1
+
 # Allowed origins for cors. Provide a space separated list of urls.
 PPR_API_ALLOWED_ORIGINS=http://localhost:8080
 

--- a/ppr-api/src/auth/authentication.py
+++ b/ppr-api/src/auth/authentication.py
@@ -1,0 +1,42 @@
+import http
+import logging
+
+import fastapi
+import fastapi.security
+import fastapi.security.http
+import requests
+from pydantic import BaseModel
+
+import config
+
+logger = logging.getLogger(__name__)
+
+bearer_scheme = fastapi.security.HTTPBearer()
+
+
+def get_user_from_auth(auth: fastapi.security.http.HTTPAuthorizationCredentials = fastapi.Depends(bearer_scheme)):
+    auth_response = requests.get('{}/users/@me'.format(config.AUTH_API_URL),
+                                 headers={'Authorization': '{} {}'.format(auth.scheme, auth.credentials)})
+
+    if not auth_response:  # status_code is unsuccessful
+        if auth_response.status_code in [http.HTTPStatus.UNAUTHORIZED, http.HTTPStatus.FORBIDDEN]:
+            body = auth_response.json()
+            raise fastapi.HTTPException(
+                status_code=auth_response.status_code, detail=body['description']
+            )
+        logger.error('Get User call failed unexpectedly with status {}.  Response body: {}'.format(
+            auth_response.status_code, auth_response.text))
+        raise fastapi.HTTPException(
+            status_code=http.HTTPStatus.INTERNAL_SERVER_ERROR
+        )
+
+    return auth_response.json()
+
+
+def get_current_user(auth_api_user: dict = fastapi.Depends(get_user_from_auth)):
+    return User(user_id=auth_api_user['keycloakGuid'], user_name=auth_api_user['username'])
+
+
+class User(BaseModel):
+    user_id: str
+    user_name: str

--- a/ppr-api/src/config.py
+++ b/ppr-api/src/config.py
@@ -12,6 +12,8 @@ import dotenv
 
 dotenv.load_dotenv()
 
+AUTH_API_URL = os.getenv("PPR_API_AUTH_API_URL")
+
 CORS_ORIGINS = os.getenv('PPR_API_ALLOWED_ORIGINS', 'http://localhost:8080 http://localhost:8081').split()
 
 DB_HOSTNAME = os.getenv('PPR_API_DB_HOSTNAME')

--- a/ppr-api/tests/unit/auth/test_authentication.py
+++ b/ppr-api/tests/unit/auth/test_authentication.py
@@ -1,0 +1,78 @@
+import http
+from unittest.mock import patch
+
+import fastapi.security.http
+import pytest
+import requests
+
+import auth.authentication
+
+
+@patch('requests.get')
+def test_get_user_from_auth_with_successful_auth(mock_get):
+    mock_get.return_value = requests.Response()
+    mock_get.return_value.status_code = http.HTTPStatus.OK
+    mock_get.return_value._content = b'{"test": "json"}'
+    credentials = fastapi.security.http.HTTPAuthorizationCredentials(scheme='Bearer', credentials='token_value')
+
+    result = auth.authentication.get_user_from_auth(credentials)
+
+    assert result == {'test': 'json'}
+
+
+@patch('requests.get')
+def test_get_user_from_auth_with_forbidden_response(mock_get):
+    mock_get.return_value = requests.Response()
+    mock_get.return_value.status_code = http.HTTPStatus.FORBIDDEN
+    mock_get.return_value._content = b'{"code": "error_code", "description": "Reason for restriction"}'
+    credentials = fastapi.security.http.HTTPAuthorizationCredentials(scheme='Bearer', credentials='token_value')
+
+    try:
+        auth.authentication.get_user_from_auth(credentials)
+    except fastapi.HTTPException as ex:
+        assert ex.status_code == http.HTTPStatus.FORBIDDEN
+        assert ex.detail == 'Reason for restriction'
+    else:
+        pytest.fail('An error was expected since the auth api returned forbidden')
+
+
+@patch('requests.get')
+def test_get_user_from_auth_with_unauthorized_response(mock_get):
+    mock_get.return_value = requests.Response()
+    mock_get.return_value.status_code = http.HTTPStatus.UNAUTHORIZED
+    mock_get.return_value._content = b'{"code": "go_away", "description": "No Permission"}'
+    credentials = fastapi.security.http.HTTPAuthorizationCredentials(scheme='Bearer', credentials='token_value')
+
+    try:
+        auth.authentication.get_user_from_auth(credentials)
+    except fastapi.HTTPException as ex:
+        assert ex.status_code == http.HTTPStatus.UNAUTHORIZED
+        assert ex.detail == 'No Permission'
+    else:
+        pytest.fail('An error was expected since the auth api returned unauthorized')
+
+
+@patch('requests.get')
+def test_get_user_from_auth_with_unexpected_response(mock_get):
+    mock_get.return_value = requests.Response()
+    mock_get.return_value.status_code = http.HTTPStatus.NOT_FOUND
+    mock_get.return_value._content = b'Non JSON Content - Not Found'
+    credentials = fastapi.security.http.HTTPAuthorizationCredentials(scheme='Bearer', credentials='token_value')
+
+    try:
+        auth.authentication.get_user_from_auth(credentials)
+    except fastapi.HTTPException as ex:
+        assert ex.status_code == http.HTTPStatus.INTERNAL_SERVER_ERROR
+        assert ex.detail == http.HTTPStatus.INTERNAL_SERVER_ERROR.phrase
+    else:
+        pytest.fail('A general error was expected since the auth api returned an unexpected response')
+
+
+def test_get_current_user():
+    auth_api_user = {'keycloakGuid': 'dad87b8e-0c80-4c8d-815b-0967cc68d65d',
+                     'username': 'bcsc/32b44e37aa6a40019de1068c4891da10'}
+
+    user = auth.authentication.get_current_user(auth_api_user)
+
+    assert user.user_id == 'dad87b8e-0c80-4c8d-815b-0967cc68d65d'
+    assert user.user_name == 'bcsc/32b44e37aa6a40019de1068c4891da10'


### PR DESCRIPTION
This can be leveraged by adding the following parameter to each endpoint that requires auth: `user: auth.authentication.User = fastapi.Depends(auth.authentication.get_current_user)`

I've left this portion out for the moment as it will break integration tests, since the tests do not have a valid token when running, so can't use the actual API.  I'll work on that next week.