### PR TITLE
Set page background colour to match content

### DIFF
--- a/ppr-ui/src/assets/styles/overrides.scss
+++ b/ppr-ui/src/assets/styles/overrides.scss
@@ -1,5 +1,9 @@
 // Vuetify Overrides
 
+.theme--light.v-application {
+  background: $gray2;
+}
+
 // Buttons
 .v-btn {
   min-width: 0;


### PR DESCRIPTION
There was a light coloured region under the page content. Set its background to be the same as the content.