### PR TITLE
Convert the API code base to use single quotes consistently.

### DIFF
--- a/.github/workflows/compile-and-test-stage.yml
+++ b/.github/workflows/compile-and-test-stage.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           pylint -E src
           pylint -E --disable=E1101 migrations
-          flake8 src migrations tests
+          flake8 src migrations tests *.py
       - name: Execute Unit Tests with PyTest
         working-directory: ppr-api
         run: |

--- a/ppr-api/migrations/env.py
+++ b/ppr-api/migrations/env.py
@@ -23,7 +23,7 @@ target_metadata = None
 
 # other values from the config, defined by the needs of env.py,
 # can be acquired:
-# my_important_option = config.get_main_option("my_important_option")
+# my_important_option = config.get_main_option('my_important_option')
 # ... etc.
 config.set_main_option('sqlalchemy.url', models.database.DATABASE_URI)
 
@@ -40,12 +40,12 @@ def run_migrations_offline():
     script output.
 
     """
-    url = config.get_main_option("sqlalchemy.url")
+    url = config.get_main_option('sqlalchemy.url')
     context.configure(
         url=url,
         target_metadata=target_metadata,
         literal_binds=True,
-        dialect_opts={"paramstyle": "named"},
+        dialect_opts={'paramstyle': 'named'},
     )
 
     with context.begin_transaction():
@@ -61,7 +61,7 @@ def run_migrations_online():
     """
     connectable = engine_from_config(
         config.get_section(config.config_ini_section),
-        prefix="sqlalchemy.",
+        prefix='sqlalchemy.',
         poolclass=pool.NullPool,
     )
 

--- a/ppr-api/requirements/dev.txt
+++ b/ppr-api/requirements/dev.txt
@@ -4,6 +4,7 @@
 autopep8
 fastapi==0.42.0 # version tied to https://github.com/tiangolo/uvicorn-gunicorn-fastapi-docker
 flake8==3.7.9
+flake8-quotes==2.1.1
 pylint==2.4.3
 pytest==5.2.2
 pytest-cov==2.8.1

--- a/ppr-api/setup.py
+++ b/ppr-api/setup.py
@@ -14,6 +14,6 @@ setup(
     author='',
     author_email='',
     description='',
-    setup_requires=["pytest-runner"],
-    tests_require=["pytest"]
+    setup_requires=['pytest-runner'],
+    tests_require=['pytest']
 )

--- a/ppr-api/src/config.py
+++ b/ppr-api/src/config.py
@@ -12,7 +12,7 @@ import dotenv
 
 dotenv.load_dotenv()
 
-AUTH_API_URL = os.getenv("PPR_API_AUTH_API_URL")
+AUTH_API_URL = os.getenv('PPR_API_AUTH_API_URL')
 
 CORS_ORIGINS = os.getenv('PPR_API_ALLOWED_ORIGINS', 'http://localhost:8080 http://localhost:8081').split()
 
@@ -24,7 +24,7 @@ DB_NAME = os.getenv('PPR_API_DB_NAME')
 DB_USERNAME = os.getenv('PPR_API_DB_USERNAME')
 DB_PASSWORD = os.getenv('PPR_API_DB_PASSWORD')
 
-IMS_API_URL = os.getenv("PPR_API_IMS_API_URL")
+IMS_API_URL = os.getenv('PPR_API_IMS_API_URL')
 
-SENTRY_DSN = os.getenv("PPR_API_SENTRY_DSN")
-SENTRY_ENVIRONMENT = os.getenv("PPR_API_SENTRY_ENVIRONMENT")
+SENTRY_DSN = os.getenv('PPR_API_SENTRY_DSN')
+SENTRY_ENVIRONMENT = os.getenv('PPR_API_SENTRY_ENVIRONMENT')

--- a/ppr-api/src/endpoints/api.py
+++ b/ppr-api/src/endpoints/api.py
@@ -8,5 +8,5 @@ from . import healthcheck
 
 router = fastapi.APIRouter()
 
-router.include_router(healthcheck.router, prefix="/operations", tags=["Operations"])
-router.include_router(search.router, tags=["Search"])
+router.include_router(healthcheck.router, prefix='/operations', tags=['Operations'])
+router.include_router(search.router, tags=['Search'])

--- a/ppr-api/src/endpoints/healthcheck.py
+++ b/ppr-api/src/endpoints/healthcheck.py
@@ -14,21 +14,21 @@ import models.patroni
 router = fastapi.APIRouter()
 logger = logging.getLogger(__name__)
 
-STATUS_UP = "UP"
-STATUS_DOWN = "DOWN"
+STATUS_UP = 'UP'
+STATUS_DOWN = 'DOWN'
 
 
-@router.get("/health")
+@router.get('/health')
 def health():
     """
     Returns a health check for this service - if reachable always indicates up.
     """
     return {
-        "status": STATUS_UP
+        'status': STATUS_UP
     }
 
 
-@router.get("/database")
+@router.get('/database')
 def database(response: responses.Response,
              session: sqlalchemy.orm.Session = fastapi.Depends(models.database.get_session)):
     """
@@ -37,7 +37,7 @@ def database(response: responses.Response,
     return db_health(response, session, 'Database delegator')
 
 
-@router.get("/patroni")
+@router.get('/patroni')
 def patroni(response: responses.Response,
             session: sqlalchemy.orm.Session = fastapi.Depends(models.patroni.get_session)):
     """
@@ -46,7 +46,7 @@ def patroni(response: responses.Response,
     return db_health(response, session, 'Patroni')
 
 
-@router.get("/edb")
+@router.get('/edb')
 def edb(response: responses.Response, session: sqlalchemy.orm.Session = fastapi.Depends(models.edb.get_session)):
     """
     Returns a health check for the reachability of the EDB (or stand-in) database.
@@ -57,20 +57,20 @@ def edb(response: responses.Response, session: sqlalchemy.orm.Session = fastapi.
 def db_health(response: responses.Response, session: sqlalchemy.orm.Session, name: str):
     try:
         start: float = time.perf_counter()
-        session.execute("SELECT 1")
+        session.execute('SELECT 1')
         elapsed_time: float = time.perf_counter() - start
 
         if elapsed_time > 1:
-            logger.info("%s health check took longer than 1 second: %s", name, elapsed_time)
+            logger.info('%s health check took longer than 1 second: %s', name, elapsed_time)
 
         return {
-            "status": STATUS_UP
+            'status': STATUS_UP
         }
     except Exception as exception:
-        logger.warning("%s health check failed", name, exc_info=True)
+        logger.warning('%s health check failed', name, exc_info=True)
         response.status_code = status.HTTP_503_SERVICE_UNAVAILABLE
 
         return {
-            "status": STATUS_DOWN,
-            "error": str(exception)
+            'status': STATUS_DOWN,
+            'error': str(exception)
         }

--- a/ppr-api/src/main.py
+++ b/ppr-api/src/main.py
@@ -15,11 +15,11 @@ app.add_middleware(
     cors.CORSMiddleware,
     allow_origins=config.CORS_ORIGINS,
     allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"]
+    allow_methods=['*'],
+    allow_headers=['*']
 )
 
 # You should use uvicorn to run the app locally.  __main__ is provided to run it in a debugger. See
 # https://fastapi.tiangolo.com/tutorial/debugging/
-if __name__ == "__main__":
-    uvicorn.run(app, host="0.0.0.0", port=8000)
+if __name__ == '__main__':
+    uvicorn.run(app, host='0.0.0.0', port=8000)

--- a/ppr-api/tests/unit/endpoints/test_healthcheck.py
+++ b/ppr-api/tests/unit/endpoints/test_healthcheck.py
@@ -4,22 +4,22 @@ from endpoints import healthcheck
 
 
 def test_database_status_without_exception():
-    expected = "UP"
+    expected = 'UP'
     response = responses.Response()
 
     actual = healthcheck.database(response, MockSession())
 
-    assert expected == actual["status"]
+    assert expected == actual['status']
     assert status.HTTP_200_OK == response.status_code
 
 
 def test_database_status_with_exception():
-    expected = "DOWN"
+    expected = 'DOWN'
     response = responses.Response()
 
     actual = healthcheck.database(response, MockSession(True))
 
-    assert expected == actual["status"]
+    assert expected == actual['status']
     assert status.HTTP_503_SERVICE_UNAVAILABLE == response.status_code
 
 
@@ -29,5 +29,5 @@ class MockSession:
 
     def execute(self, sql):
         if self.should_fail:
-            raise Exception("execute failed intentionally")
+            raise Exception('execute failed intentionally')
         return None


### PR DESCRIPTION
Includes the addition of `flake8-quotes` extension for flake8.