### PR TITLE
Fix the reactive loading problem

### DIFF
--- a/ppr-ui/src/App.vue
+++ b/ppr-ui/src/App.vue
@@ -21,7 +21,6 @@ import { provideRouter, useRouter } from '@/router/router'
 import { provideSearcherSerial } from '@/search/search-serial'
 import { provideSearcherRegNum } from '@/search/search-regnum'
 import AppData from '@/utils/app-data'
-import { initializeVueLdClient } from '@/flags/ld-client'
 import { APP_PATH } from '@/utils/config-helper'
 
 const DefaultLayout = 'public'
@@ -37,23 +36,11 @@ function authAPIURL(): string {
 }
 
 
-/*
-  NOTE: the following userKey is TEMPORARY and will disappear when we get auth set up.
-  Create one user id per session.
- */
-const userKey = sessionStorage.getItem('userKey') ? sessionStorage.getItem('userKey') : 'unauthenticated-user'
-sessionStorage.setItem('userKey', userKey)
-
 export default createComponent({
   components: {
     LoadIndicator
   },
   setup(): Data {
-    // Make the connection to the LD server. We could explore anonymous users if we need to.
-    // For now we use a fixed per session user id.
-    // Also note that this initialization will need to happen AFTER auth.
-    initializeVueLdClient(AppData.config.launchDarklyClientKey, userKey)
-
     provide('originUrl', origin())
     provide('authApiUrl', authAPIURL())
     provide('configuration', ref(AppData.config))

--- a/ppr-ui/src/main.ts
+++ b/ppr-ui/src/main.ts
@@ -11,6 +11,7 @@ import layoutUser from '@/layouts/LayoutUser.vue'
 import SentryHelper from '@/utils/sentry-helper'
 import './assets/styles/styles.scss'
 import { Config } from "@/utils/app-data"
+import { initializeVueLdClient } from '@/flags/ld-client'
 
 const opts = { iconfont: 'mdi' }
 
@@ -21,9 +22,20 @@ Vue.config.productionTip = false
 Vue.component('public-layout', layoutPublic)
 Vue.component('user-layout', layoutUser)
 
+const userKey = sessionStorage.getItem('userKey') ? sessionStorage.getItem('userKey') : 'unauthenticated-user'
+sessionStorage.setItem('userKey', userKey)
+let appConfig: Config
+
 configHelper.fetchConfig()
-  .then((appConfig: Config): void => {
-    SentryHelper.setup(appConfig)
+  .then((cfg: Config): void => {
+    appConfig = cfg
+    return SentryHelper.setup(appConfig)
+  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+  }).then(() => {
+    return initializeVueLdClient(appConfig.launchDarklyClientKey, userKey)
+  })
+  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+  .then(() => {
     new Vue({
       vuetify: new Vuetify(opts),
       router,


### PR DESCRIPTION
The feature flags are to be reactive yet they are constructed and dependent on the loading of the LD client that needs to happen before the flags are created.   I believe we're having these chicken and egg problems because the Vue Composition API is using Vue 2.0 methods and when Vue 3 is released these problems will go away. Hopefully.  Search for info on Vue 3 and proxying data.

Several lines include this:
// eslint-disable-next-line @typescript-eslint/explicit-function-return-type

We need this fix for demo tomorrow. It was easier to use these disables than to figure out what Typescript wanted.  Maybe a reviewer has an idea?