### PR TITLE
Add userid on search and registration

### DIFF
--- a/ppr-api/migrations/versions/0268e186a129_add_uuid_supporting_userid.py
+++ b/ppr-api/migrations/versions/0268e186a129_add_uuid_supporting_userid.py
@@ -1,0 +1,28 @@
+"""add UUID supporting userid
+
+Revision ID: 0268e186a129
+Revises: b4ee1da81531
+Create Date: 2020-02-04 10:17:48.490753
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '0268e186a129'
+down_revision = 'b4ee1da81531'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('search', sa.Column('user_id', sa.String(length=36)))
+    op.add_column('registration', sa.Column('user_id', sa.String(length=36)))
+    op.drop_column('financing_statement', 'user_id')
+
+
+def downgrade():
+    op.add_column('financing_statement', sa.Column('user_id', sa.String(length=8)))
+    op.drop_column('registration', 'user_id')
+    op.drop_column('search', 'user_id')

--- a/ppr-api/migrations/versions/5f4529578e39_create_financing_statement_code_tables.py
+++ b/ppr-api/migrations/versions/5f4529578e39_create_financing_statement_code_tables.py
@@ -1,7 +1,7 @@
 """Create financing statement_code_tables
 
 Revision ID: 5f4529578e39
-Revises: fc3c53132a9b
+Revises: 1461b03c20de
 Create Date: 2020-01-27 10:21:47.141620
 
 """

--- a/ppr-api/migrations/versions/947ffeeeda60_create_foreign_key_relationship_between_.py
+++ b/ppr-api/migrations/versions/947ffeeeda60_create_foreign_key_relationship_between_.py
@@ -1,7 +1,7 @@
 """Create foreign key relationship between search_result and registration
 
 Revision ID: 947ffeeeda60
-Revises: 1461b03c20de
+Revises: fc3c53132a9b
 Create Date: 2020-01-24 16:07:20.288676
 
 """

--- a/ppr-api/migrations/versions/b4ee1da81531_create_financing_statement_party_tables.py
+++ b/ppr-api/migrations/versions/b4ee1da81531_create_financing_statement_party_tables.py
@@ -1,6 +1,6 @@
 """create financing statement party tables
 
-Revision ID: ebfec5aa1a13
+Revision ID: b4ee1da81531
 Revises: 34af2f12a9ae
 Create Date: 2020-01-31 14:14:31.169902
 

--- a/ppr-api/migrations/versions/fc3c53132a9b_create_financing_statement_document_tables.py
+++ b/ppr-api/migrations/versions/fc3c53132a9b_create_financing_statement_document_tables.py
@@ -1,7 +1,7 @@
 """Create financing statement document tables
 
 Revision ID: fc3c53132a9b
-Revises: 1461b03c20de
+Revises: 5f4529578e39
 Create Date: 2020-01-24 10:47:29.158143
 
 """

--- a/ppr-api/src/models/financing_statement.py
+++ b/ppr-api/src/models/financing_statement.py
@@ -15,7 +15,6 @@ class FinancingStatement(BaseORM):
     expiry_date = sqlalchemy.Column(sqlalchemy.Date)
     discharged = sqlalchemy.Column(sqlalchemy.BOOLEAN)
     last_updated = sqlalchemy.Column('last_update_timestamp', sqlalchemy.DateTime, onupdate=sqlalchemy.func.now())
-    user_id = sqlalchemy.Column(sqlalchemy.String(length=8))
 
     events = sqlalchemy.orm.relationship('FinancingStatementEvent', back_populates='base_registration')
 

--- a/ppr-api/tests/integration/api/test_search.py
+++ b/ppr-api/tests/integration/api/test_search.py
@@ -133,7 +133,7 @@ def create_test_financing_statement(num_of_events: int = 1):
     try:
         reg_num = next_reg_number(db)
         fin_stmt = models.financing_statement.FinancingStatement(
-            registration_number=reg_num, status='A', life_in_years=-1, user_id=-1,
+            registration_number=reg_num, status='A', life_in_years=-1,
             registration_type_code=schemas.financing_statement.RegistrationType.SECURITY_AGREEMENT.value
         )
         event = models.financing_statement.FinancingStatementEvent(registration_number=reg_num)


### PR DESCRIPTION
- Update existing migrations so the revisions in filenames and documentation strings reflect the correct values
- Add a new migration which adds a uuid supporting user_id to search and registration tables, in order to capture users who make changes.
- Dropped the existing user_id column from financing_statement as it is not currently helpful
