### PR TITLE
Create a re-usable deployment script configured for the development environment

### DIFF
--- a/ppr-api/openshift/README.md
+++ b/ppr-api/openshift/README.md
@@ -10,18 +10,36 @@ $ oc process -f ppr-api/openshift/ppr-api-bc.yaml | oc -n zwmtib-tools apply -f 
 
 ## Development Namespace `DeploymentConfig`
 
-```
-$ oc process -f ppr-api/openshift/ppr-api-dc.yaml -p AUTH_API_URL=https://auth-api-dev.pathfinder.gov.bc.ca/api/v1 -p CORS_ORIGINS="http://localhost:8080 https://dev.bcregistry.ca https://ppr-dev.pathfinder.gov.bc.ca" -p ENVIRONMENT=dev -p IMAGE_TAG=dev -p ROUTE_URL=ppr-api-dev.pathfinder.gov.bc.ca | oc -n zwmtib-dev apply -f -
+```bash
+oc process -f ppr-api/openshift/ppr-api-dc.yaml \
+    -p AUTH_API_URL=https://auth-api-dev.pathfinder.gov.bc.ca/api/v1 \
+    -p CORS_ORIGINS="http://localhost:8080 https://dev.bcregistry.ca https://ppr-dev.pathfinder.gov.bc.ca" \
+    -p ENVIRONMENT=dev \
+    -p IMAGE_TAG=dev \
+    -p ROUTE_URL=ppr-api-dev.pathfinder.gov.bc.ca \
+    | oc -n zwmtib-dev apply -f -
 ```
 
 ## Test Namespace `DeploymentConfig`
 
-```
-$ oc process -f ppr-api/openshift/ppr-api-dc.yaml -p AUTH_API_URL=https://auth-api-test.pathfinder.gov.bc.ca/api/v1 -p CORS_ORIGINS=https://test.bcregistry.ca -p ENVIRONMENT=test -p IMAGE_TAG=test -p ROUTE_URL=ppr-api-test.pathfinder.gov.bc.ca | oc -n zwmtib-test apply -f -
+```bash
+oc process -f ppr-api/openshift/ppr-api-dc.yaml \
+    -p AUTH_API_URL=https://auth-api-test.pathfinder.gov.bc.ca/api/v1 \
+    -p CORS_ORIGINS=https://test.bcregistry.ca \
+    -p ENVIRONMENT=test \
+    -p IMAGE_TAG=test \
+    -p ROUTE_URL=ppr-api-test.pathfinder.gov.bc.ca \
+    | oc -n zwmtib-test apply -f -
 ```
 
 ## Production Namespace `DeploymentConfig`
 
-```
-$ oc process -f ppr-api/openshift/ppr-api-dc.yaml -p AUTH_API_URL=https://auth-api.pathfinder.gov.bc.ca/api/v1 -p CORS_ORIGINS=https://www.bcregistry.ca -p ENVIRONMENT=prod -p IMAGE_TAG=prod -p ROUTE_URL=ppr-api.pathfinder.gov.bc.ca | oc -n zwmtib-prod apply -f -
+```bash
+oc process -f ppr-api/openshift/ppr-api-dc.yaml \
+    -p AUTH_API_URL=https://auth-api.pathfinder.gov.bc.ca/api/v1 \
+    -p CORS_ORIGINS=https://www.bcregistry.ca \
+    -p ENVIRONMENT=prod \
+    -p IMAGE_TAG=prod \
+    -p ROUTE_URL=ppr-api.pathfinder.gov.bc.ca \
+    | oc -n zwmtib-prod apply -f -
 ```

--- a/ppr-api/openshift/deploy_dev.sh
+++ b/ppr-api/openshift/deploy_dev.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Deploy PPR API to the development environment
+
+export NAME_PLATE=zwmtib
+export ENVIRONMENT=dev
+export SOURCE_TAG=latest
+
+export AUTH_API_URL=https://auth-api-dev.pathfinder.gov.bc.ca/api/v1
+export CORS_ORIGINS="http://localhost:8080 https://dev.bcregistry.ca https://ppr-dev.pathfinder.gov.bc.ca"
+export ROUTE_URL=ppr-api-dev.pathfinder.gov.bc.ca
+
+./deploy_ppr_api.sh

--- a/ppr-api/openshift/deploy_ppr_api.sh
+++ b/ppr-api/openshift/deploy_ppr_api.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Leverage oc to deploy the PPR API to an openshift environment
+
+: ${NAME_PLATE:?"NAME_PLATE environment variable is required"}
+: ${ENVIRONMENT:?"ENVIRONMENT environment variable is required"}
+: ${SOURCE_TAG:?"SOURCE_TAG environment variable is required"}
+: ${AUTH_API_URL:?"AUTH_API_URL environment variable is required"}
+: ${CORS_ORIGINS:?"CORS_ORIGINS environment variable is required"}
+: ${ROUTE_URL:?"ROUTE_URL environment variable is required"}
+
+env_namespace=${NAME_PLATE}-$ENVIRONMENT
+tools_namespace=${NAME_PLATE}-tools
+source_tag=$SOURCE_TAG
+target_tag=$ENVIRONMENT
+
+# Apply the current configuration to the environment. There is no rollout trigger on configuration changes.
+oc process -f ppr-api-dc.yaml \
+  -p AUTH_API_URL=$AUTH_API_URL \
+  -p CORS_ORIGINS="$CORS_ORIGINS" \
+  -p ENVIRONMENT=$ENVIRONMENT \
+  -p IMAGE_TAG=$ENVIRONMENT \
+  -p ROUTE_URL=$ROUTE_URL \
+  | oc apply -f - -n $env_namespace
+
+# Tag the new image which triggers a rollout. In the future we may consider removing the trigger to explicitly run:
+#   `oc rollout latest dc/ppr-api -n $env_namespace`
+oc tag ppr-api:$source_tag ppr-api:$target_tag -n $tools_namespace
+
+# Wait for rollout to finish
+oc rollout status dc/ppr-api -w --timeout=10m -n $env_namespace

--- a/ppr-api/openshift/ppr-api-dc.yaml
+++ b/ppr-api/openshift/ppr-api-dc.yaml
@@ -109,7 +109,6 @@ objects:
           name: ${API_NAME}:${IMAGE_TAG}
           namespace: zwmtib-tools
       type: ImageChange
-    - type: ConfigChange
 - apiVersion: v1
   kind: Service
   metadata:
@@ -169,7 +168,7 @@ parameters:
   name: ENVIRONMENT
   required: true
   value: dev
-- description: The image tag to build from.
+- description: The image tag to deploy from.
   displayName: Image Tag
   name: IMAGE_TAG
   required: true


### PR DESCRIPTION
For the time being this can be used manually from the command line.  One the image is pushed by GitHub actions after a merge to `master`, you can deploy to dev with:
1. `cd ppr-api/openshift`
2. `./deploy_dev.sh`

I've removed the "configuration trigger" in the DC file, so even though the script gets re-applied, the rollout won't happen until the image is re-tagged.

The next steps are to start automating this process and leverage 1Password.