### PR TITLE
Create payment request on new search in API

### DIFF
--- a/ppr-api/src/auth/authentication.py
+++ b/ppr-api/src/auth/authentication.py
@@ -14,21 +14,23 @@ logger = logging.getLogger(__name__)
 bearer_scheme = fastapi.security.HTTPBearer()
 
 
+def check_auth_response(response: requests.Response):
+    if response.status_code in [http.HTTPStatus.UNAUTHORIZED, http.HTTPStatus.FORBIDDEN]:
+        body = response.json()
+        raise fastapi.HTTPException(
+            status_code=response.status_code, detail=body['description']
+        )
+
+
 def get_user_from_auth(auth: fastapi.security.http.HTTPAuthorizationCredentials = fastapi.Depends(bearer_scheme)):
     auth_response = requests.get('{}/users/@me'.format(config.AUTH_API_URL),
                                  headers={'Authorization': '{} {}'.format(auth.scheme, auth.credentials)})
 
+    check_auth_response(auth_response)
     if not auth_response:  # status_code is unsuccessful
-        if auth_response.status_code in [http.HTTPStatus.UNAUTHORIZED, http.HTTPStatus.FORBIDDEN]:
-            body = auth_response.json()
-            raise fastapi.HTTPException(
-                status_code=auth_response.status_code, detail=body['description']
-            )
         logger.error('Get User call failed unexpectedly with status {}.  Response body: {}'.format(
             auth_response.status_code, auth_response.text))
-        raise fastapi.HTTPException(
-            status_code=http.HTTPStatus.INTERNAL_SERVER_ERROR
-        )
+        raise fastapi.HTTPException(status_code=http.HTTPStatus.INTERNAL_SERVER_ERROR)
 
     return auth_response.json()
 

--- a/ppr-api/src/schemas/search.py
+++ b/ppr-api/src/schemas/search.py
@@ -4,6 +4,7 @@ import enum
 import pydantic
 
 import schemas.financing_statement
+import services.payment_service
 
 
 class SearchType(enum.Enum):
@@ -60,6 +61,7 @@ class SearchBase(pydantic.BaseModel):
 class Search(SearchBase):
     id: int
     searchDateTime: datetime.datetime
+    payment: services.payment_service.Payment = None
 
     class Config:
         orm_mode = True

--- a/ppr-api/src/services/payment_service.py
+++ b/ppr-api/src/services/payment_service.py
@@ -1,0 +1,61 @@
+import http
+import logging
+
+from fastapi import Depends, HTTPException
+from fastapi.security.http import HTTPAuthorizationCredentials
+from pydantic import BaseModel
+import requests
+
+import config
+import auth.authentication
+
+logger = logging.getLogger(__name__)
+
+# TODO This is a temporary payload to enable interaction with payments.  Replace with a coded solution base on the user.
+HARDCODED_PAYLOAD = """{
+    "paymentInfo": {
+        "methodOfPayment": "CC"
+    },
+    "businessInfo": {
+        "businessIdentifier": "CP0000019",
+        "corpType": "CP",
+        "businessName": "ABC Corp",
+        "contactInfo": {
+            "city": "Victoria",
+            "postalCode": "V8P2P2",
+            "province": "BC",
+            "addressLine1": "100 Douglas Street",
+            "country": "CA"
+        }
+    },
+    "filingInfo": {
+        "filingTypes": [
+            {
+                "filingTypeCode": "OTADD"
+            }
+        ]
+    }
+}"""
+
+
+def create_payment_request(auth_header: HTTPAuthorizationCredentials = Depends(auth.authentication.bearer_scheme)):
+    pay_response = requests.post('{}/payment-requests'.format(config.PAY_API_URL), json=eval(HARDCODED_PAYLOAD),
+                                 headers={'Authorization': '{} {}'.format(auth_header.scheme, auth_header.credentials)})
+
+    auth.authentication.check_auth_response(pay_response)
+    if not pay_response:  # status_code is unsuccessful
+        logger.error('Create Payment call failed unexpectedly with status {}.  Response body: {}'.format(
+            pay_response.status_code, pay_response.text))
+        raise HTTPException(status_code=http.HTTPStatus.INTERNAL_SERVER_ERROR)
+
+    return pay_response.json()
+
+
+def get_payment(api_payment: dict = Depends(create_payment_request)):
+    return Payment(id=api_payment['id'], status=api_payment['statusCode'], method=api_payment['paymentMethod'])
+
+
+class Payment(BaseModel):
+    id: int
+    status: str
+    method: str

--- a/ppr-api/tests/integration/api/test_search.py
+++ b/ppr-api/tests/integration/api/test_search.py
@@ -21,7 +21,7 @@ def test_read_search():
     assert search['searchDateTime'] == search_rec.creation_date_time.isoformat(timespec='seconds')
 
 
-def test_create_registration_number_search(default_current_user):
+def test_create_registration_number_search():
     search_input = {'type': 'REGISTRATION_NUMBER', 'criteria': {'value': '987654Z'}}
 
     rv = client.post('/searches', json=search_input)
@@ -39,6 +39,20 @@ def test_create_registration_number_search(default_current_user):
     assert stored.criteria == {'value': '987654Z'}
     assert stored.user_id == 'fake_user_id'  # Default user for integration tests
     assert body['searchDateTime'] == stored.creation_date_time.isoformat(timespec='seconds')
+
+
+def test_create_search_returns_payment_info():
+    search_input = {'type': 'SERIAL_NUMBER', 'criteria': {'value': 'ABC123456'}}
+
+    rv = client.post('/searches', json=search_input)
+
+    body = rv.json()
+
+    # Ensure default payment info for integration tests is provided.  See ../conftest.py
+    assert 'payment' in body
+    assert body['payment']['id'] == 1234
+    assert body['payment']['status'] == 'CREATED'
+    assert body['payment']['method'] == 'CC'
 
 
 def test_create_search_with_exact_match():

--- a/ppr-api/tests/integration/conftest.py
+++ b/ppr-api/tests/integration/conftest.py
@@ -1,6 +1,7 @@
 import pytest
 
 import auth.authentication
+import services.payment_service
 import main
 
 
@@ -11,3 +12,12 @@ def default_current_user():
         return auth.authentication.User(user_id='fake_user_id', user_name='fake_user_name')
 
     main.app.dependency_overrides[auth.authentication.get_current_user] = mock_get_current_user
+
+
+@pytest.fixture(autouse=True)
+def default_payment():
+    """Override the get_payment Fast API dependency to eliminate the need for an external Payment service"""
+    def mock_get_payment():
+        return services.payment_service.Payment(id=1234, status='CREATED', method='CC')
+
+    main.app.dependency_overrides[services.payment_service.get_payment] = mock_get_payment

--- a/ppr-api/tests/unit/services/test_payment_service.py
+++ b/ppr-api/tests/unit/services/test_payment_service.py
@@ -1,0 +1,62 @@
+import http
+from unittest.mock import patch
+
+import fastapi.security.http
+import pytest
+import requests
+
+import services.payment_service
+
+
+@patch('requests.post')
+def test_create_payment_request_is_successful(mock_post):
+    mock_post.return_value = requests.Response()
+    mock_post.return_value.status_code = http.HTTPStatus.CREATED.value
+    mock_post.return_value._content = b'{"test": "json"}'
+    credentials = fastapi.security.http.HTTPAuthorizationCredentials(scheme='Bearer', credentials='token_value')
+
+    result = services.payment_service.create_payment_request(credentials)
+
+    assert result == {'test': 'json'}
+
+
+@patch('requests.post')
+def test_create_payment_request_with_bad_auth_response(mock_post):
+    mock_post.return_value = requests.Response()
+    mock_post.return_value.status_code = http.HTTPStatus.FORBIDDEN
+    mock_post.return_value._content = b'{"code": "error_code", "description": "Reason for restriction"}'
+    credentials = fastapi.security.http.HTTPAuthorizationCredentials(scheme='Bearer', credentials='token_value')
+
+    try:
+        services.payment_service.create_payment_request(credentials)
+    except fastapi.HTTPException as ex:
+        assert ex.status_code == http.HTTPStatus.FORBIDDEN.value
+        assert ex.detail == 'Reason for restriction'
+    else:
+        pytest.fail('An error was expected since the payment api returned forbidden')
+
+
+@patch('requests.post')
+def test_create_payment_request_with_unexpected_response(mock_post):
+    mock_post.return_value = requests.Response()
+    mock_post.return_value.status_code = http.HTTPStatus.NOT_FOUND
+    mock_post.return_value._content = b'Non JSON Content - Not Found'
+    credentials = fastapi.security.http.HTTPAuthorizationCredentials(scheme='Bearer', credentials='token_value')
+
+    try:
+        services.payment_service.create_payment_request(credentials)
+    except fastapi.HTTPException as ex:
+        assert ex.status_code == http.HTTPStatus.INTERNAL_SERVER_ERROR.value
+        assert ex.detail == http.HTTPStatus.INTERNAL_SERVER_ERROR.phrase
+    else:
+        pytest.fail('A general error was expected since the payment api returned an unexpected response')
+
+
+def test_get_current_user():
+    api_response = {'id': 1234, 'paymentMethod': 'CC', 'statusCode': 'CREATED'}
+
+    payment = services.payment_service.get_payment(api_response)
+
+    assert payment.id == 1234
+    assert payment.status == 'CREATED'
+    assert payment.method == 'CC'


### PR DESCRIPTION
When a search is created, send a request to the Payment Service to create a new payment record.  Here's a sample response. Updates to the spec will follow when we're happy with this approach.

This change does not include persisting the payment information, nor returning it in a GET.  The intent for now is to enable the UI to receive a valid payment id so it can handle the workflow correctly.

This is a sample POST response:
```json
{
    "type": "REGISTRATION_NUMBER",
    "criteria": {
        "value": "123456B"
    },
    "id": 35,
    "searchDateTime": "2020-02-14T22:54:14+00:00",
    "payment": {
        "id": 1641,
        "status": "CREATED",
        "method": "CC"
    }
}
```