### PR TITLE
Change the PPR CI Build to run only when PPR is updated directly

### DIFF
--- a/.github/workflows/ppr-api-ci.yml
+++ b/.github/workflows/ppr-api-ci.yml
@@ -3,6 +3,7 @@ name: Build and Push Docker Images
 on:
   push:
     branches: [master]
+    paths: ['ppr-api/**']
 
 jobs:
   ppr-api-image-build:


### PR DESCRIPTION
Since adding this workflow, we're seeing a large number of image tags for unrelated changes.  It creates quite a bit of noise in the OpenShift image streams, so changing it to only create ppr-api images when ppr-api is changed.