### PR TITLE
Update common to 2.0.50

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -18134,9 +18134,9 @@
       }
     },
     "sbc-common-components": {
-      "version": "2.0.47",
-      "resolved": "https://registry.npmjs.org/sbc-common-components/-/sbc-common-components-2.0.47.tgz",
-      "integrity": "sha512-OWA+emNFsBROAdaQd20eyo5z7iEOlTmndTYnQSXlhjDZ8dq5UsbC4tYtFV/YYYb0nCRThVJ+vd+5CH8PKZGrvw==",
+      "version": "2.0.50",
+      "resolved": "https://registry.npmjs.org/sbc-common-components/-/sbc-common-components-2.0.50.tgz",
+      "integrity": "sha512-T0w+nV8oAU/2IFPKdAFYlQfB3fYXBBczS1gEGx6JVYNKGvD1Kh6xBb130fjtIaz29omGtFCw5qZ1ru0zdtW02Q==",
       "requires": {
         "@mdi/font": "^4.5.95",
         "axios": "^0.18.0",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -36,7 +36,7 @@
     "jwt-decode": "^2.2.0",
     "launchdarkly-js-client-sdk": "^2.16.3",
     "register-service-worker": "^1.6.2",
-    "sbc-common-components": "^2.0.47",
+    "sbc-common-components": "^2.0.50",
     "ua-parser-js": "^0.7.21",
     "vue": "^2.6.11",
     "vue-class-component": "^7.2.2",

--- a/ppr-ui/public/config/configuration.json.sample
+++ b/ppr-ui/public/config/configuration.json.sample
@@ -1,6 +1,6 @@
 {
   "API_URL": "http://localhost:8000/",
-  "AUTH_API_URL": "https://dev.bcregistry.ca/cooperatives/auth",
+  "AUTH_URL": "https://dev.bcregistry.ca/cooperatives/auth",
   "LAUNCH_DARKLY_CLIENT_KEY": "Client side ID from https://app.launchdarkly.com/settings/projects",
   "PAY_API_URL": "https://pay-api-test.pathfinder.gov.bc.ca/api/v1/",
   "SENTRY_DSN": "",

--- a/ppr-ui/src/layouts/LayoutHeader.vue
+++ b/ppr-ui/src/layouts/LayoutHeader.vue
@@ -1,8 +1,8 @@
 
 <template>
   <sbc-header
-    redirect-on-login-success="encoded"
-    redirect-on-logout="encode"
+    :redirect-on-login-success="originUrl"
+    :redirect-on-logout="originUrl"
   />
 </template>
 
@@ -15,10 +15,11 @@ export default createComponent({
     SbcHeader
   },
   setup() {
-    const oUrl = inject('originUrl') as string
-    const encoded = encodeURIComponent(oUrl)
+    const originUrl = inject('originUrl') as string
+    // Need this debug until auth redirects are verified to work on at least Dev if not all the way to Prod. Then can remove.
+    console.debug('send this url to header', originUrl)
     return {
-      encoded
+      originUrl
     }
   }
 })

--- a/ppr-ui/src/utils/Config.ts
+++ b/ppr-ui/src/utils/Config.ts
@@ -5,7 +5,7 @@ import axiosAuth from '@/utils/axios-auth'
  */
 interface ConfigSettings {
   API_URL: string;
-  AUTH_API_URL: string;
+  AUTH_URL: string;
   LAUNCH_DARKLY_CLIENT_KEY: string;
   PAY_API_URL: string;
   SENTRY_DSN: string;
@@ -34,11 +34,14 @@ export default class Config {
         const settings: ConfigSettings = (typeof response.data === 'string') ? JSON.parse(response.data) : response.data
 
         this.setStoreValue('API_URL', settings.API_URL)
-        this.setStoreValue('AUTH_API_URL', settings.AUTH_API_URL)
+        this.setStoreValue('AUTH_URL', settings.AUTH_URL)
         this.setStoreValue('LAUNCH_DARKLY_CLIENT_KEY', settings.LAUNCH_DARKLY_CLIENT_KEY)
         this.setStoreValue('PAY_API_URL', settings.PAY_API_URL)
         this.setStoreValue('SENTRY_DSN', settings.SENTRY_DSN)
         this.setStoreValue('SENTRY_ENVIRONMENT', settings.SENTRY_ENVIRONMENT)
+
+        // setup for the SBC common components
+        this.setStoreValue('AUTH_API_CONFIG', JSON.stringify(response.data))
       })
   }
 
@@ -53,7 +56,7 @@ export default class Config {
    * Gets the URL for the authentication API.
    */
   public static get authApiUrl(): string {
-    return this.getStoreValue('AUTH_API_URL')
+    return this.getStoreValue('AUTH_URL')
   }
 
   /**

--- a/ppr-ui/tests/unit/utils/config-helper.spec.ts
+++ b/ppr-ui/tests/unit/utils/config-helper.spec.ts
@@ -26,7 +26,7 @@ describe('Config', (): void => {
   })
 
   it('has non-empty string value for authApiUrl', (): void => {
-    mockedAxios.get.mockResolvedValueOnce({ data: '{ "AUTH_API_URL": "ABC123" }' })
+    mockedAxios.get.mockResolvedValueOnce({ data: '{ "AUTH_URL": "ABC123" }' })
 
     Config.setup().then((): void => {
       expect(Config.authApiUrl).toBe('ABC123')


### PR DESCRIPTION
Use the latest version to get login/logout redirect
Requires a change in the config map from AUTH_API_URL to AUTH_URL