### PR TITLE
Restore sticky footer fix

### DIFF
--- a/ppr-ui/src/assets/styles/styles.scss
+++ b/ppr-ui/src/assets/styles/styles.scss
@@ -8,3 +8,9 @@ and mixins there is no CSS code bloat.
 @import 'layout';
 @import "overrides";
 
+.app-footer {
+    position: fixed;
+    left: 0;
+    bottom: 0;
+    width: 100%;
+  }


### PR DESCRIPTION
After syncing the style sheets with the other teams the footer started to float again.  Placing the fix in the per app styles.scss file rather than one of the other style sheets that may, again, be synced with other teams.
For the original issue see issue 232 - sticky footer #389 