### PR TITLE
Add an API endpoint to create financing statements

### DIFF
--- a/ppr-api/requirements.txt
+++ b/ppr-api/requirements.txt
@@ -4,6 +4,7 @@ datedelta==1.3
 email-validator==1.0.5 # Uvicorn complains without this.
 psycopg2-binary==2.8.4
 python-dotenv==0.10.3
+pytz==2019.3
 requests==2.22.0
 sentry-sdk==0.14.1
 sqlalchemy==1.3.10

--- a/ppr-api/requirements/dev.txt
+++ b/ppr-api/requirements/dev.txt
@@ -5,6 +5,7 @@ autopep8
 fastapi==0.42.0 # version tied to https://github.com/tiangolo/uvicorn-gunicorn-fastapi-docker
 flake8==3.7.9
 flake8-quotes==2.1.1
+freezegun==0.3.15
 pylint==2.4.3
 pytest==5.2.2
 pytest-cov==2.8.1

--- a/ppr-api/src/endpoints/financing_statement.py
+++ b/ppr-api/src/endpoints/financing_statement.py
@@ -1,6 +1,7 @@
 """ Define the endpoints for managing Financing Statements. """
 
 import fastapi
+from starlette import responses, status
 
 import auth.authentication
 import models.financing_statement
@@ -8,6 +9,19 @@ from repository.financing_statement_repository import FinancingStatementReposito
 import schemas.financing_statement
 
 router = fastapi.APIRouter()
+
+
+@router.post('/financing-statements', response_model=schemas.financing_statement.FinancingStatement,
+             response_model_by_alias=False)
+def create_financing_statement(response: responses.Response,
+                               fs_input: schemas.financing_statement.FinancingStatementBase,
+                               fs_repo: FinancingStatementRepository = fastapi.Depends(),
+                               user: auth.authentication.User = fastapi.Depends(auth.authentication.get_current_user)):
+    model = fs_repo.create_financing_statement(fs_input, user)
+
+    response.status_code = status.HTTP_201_CREATED
+
+    return map_financing_statement_model_to_schema(model)
 
 
 @router.get('/financing-statements/{base_reg_num}', response_model=schemas.financing_statement.FinancingStatement,

--- a/ppr-api/src/models/financing_statement.py
+++ b/ppr-api/src/models/financing_statement.py
@@ -14,7 +14,8 @@ class FinancingStatement(BaseORM):
     life_in_years = sqlalchemy.Column('life', sqlalchemy.Integer)
     expiry_date = sqlalchemy.Column(sqlalchemy.Date)
     discharged = sqlalchemy.Column(sqlalchemy.BOOLEAN)
-    last_updated = sqlalchemy.Column('last_update_timestamp', sqlalchemy.DateTime, onupdate=sqlalchemy.func.now())
+    last_updated = sqlalchemy.Column('last_update_timestamp', sqlalchemy.DateTime, server_default=sqlalchemy.func.now(),
+                                     onupdate=sqlalchemy.func.now())
 
     events = sqlalchemy.orm.relationship('FinancingStatementEvent', back_populates='base_registration')
 

--- a/ppr-api/src/repository/financing_statement_repository.py
+++ b/ppr-api/src/repository/financing_statement_repository.py
@@ -1,7 +1,12 @@
+import datedelta
 import fastapi
 import sqlalchemy.orm
 
+import auth.authentication
+import models.database
 import models.financing_statement
+import schemas.financing_statement
+import utils.datetime
 
 
 class FinancingStatementRepository:
@@ -10,6 +15,26 @@ class FinancingStatementRepository:
     def __init__(self, session: sqlalchemy.orm.Session = fastapi.Depends(models.database.get_session)):
         self.db = session
 
+    def create_financing_statement(self, fs_input: schemas.financing_statement.FinancingStatementBase,
+                                   user: auth.authentication.User):
+        reg_num = self.next_registration_number()
+        years = fs_input.years or -1
+        expiry_date = utils.datetime.today_pacific() + datedelta.datedelta(years=years) if years > 0 else None
+
+        model = models.financing_statement.FinancingStatement(
+            registration_number=reg_num, status='A', life_in_years=years, expiry_date=expiry_date,
+            registration_type_code=schemas.financing_statement.RegistrationType[fs_input.type].value
+        )
+        model.events.append(
+            models.financing_statement.FinancingStatementEvent(registration_number=reg_num, user_id=user.user_id)
+        )
+
+        self.db.add(model)
+        self.db.flush()
+        self.db.refresh(model)
+
+        return model
+
     def get_financing_statement(self, base_registration_number: str):
         return self.db.query(models.financing_statement.FinancingStatement).get(base_registration_number)
 
@@ -17,3 +42,6 @@ class FinancingStatementRepository:
         return self.db.query(models.financing_statement.FinancingStatementEvent)\
             .filter(models.financing_statement.FinancingStatementEvent.registration_number.ilike(registration_number))\
             .first()
+
+    def next_registration_number(self):
+        return str(self.db.execute(sqlalchemy.Sequence('reg_number_seq')))

--- a/ppr-api/src/utils/datetime.py
+++ b/ppr-api/src/utils/datetime.py
@@ -1,0 +1,11 @@
+import datetime
+import time
+
+import pytz
+
+PACIFIC_TZ = pytz.timezone('America/Vancouver')
+
+
+def today_pacific():
+    now_pacific = datetime.datetime.fromtimestamp(time.time(), PACIFIC_TZ)
+    return now_pacific.date()

--- a/ppr-api/tests/integration/api/test_financing_statement.py
+++ b/ppr-api/tests/integration/api/test_financing_statement.py
@@ -18,3 +18,49 @@ def test_read_financing_statement_with_root_object_details():
     assert body['expiryDate'] == fin_stmt.expiry_date.isoformat()
     assert body['years'] == 5
     assert body['registrationDateTime'] == fin_stmt.events[0].registration_date.isoformat(timespec='seconds')
+
+
+def test_read_financing_statement_with_no_expiry():
+    fin_stmt = sample_data_utility.create_test_financing_statement(type_code='SA', years=-1)
+
+    rv = client.get('/financing-statements/{}'.format(fin_stmt.registration_number))
+    assert rv.status_code == 200
+    body = rv.json()
+
+    assert body['expiryDate'] is None
+    assert body['years'] is None
+
+
+def test_create_financing_statement_for_root_object_details():
+    request_payload = {
+        'type': 'SECURITY_AGREEMENT',
+        'years': 5,
+        'registeringParty': {},
+        'securedParties': [],
+        'debtors': [],
+        'vehicleCollateral': [],
+        'generalCollateral': []
+    }
+
+    rv = client.post('/financing-statements', json=request_payload)
+
+    assert rv.status_code == 201
+    body = rv.json()
+    assert body['type'] == 'SECURITY_AGREEMENT'
+    assert body['years'] == 5
+
+    registration_number = body['baseRegistrationNumber']
+
+    stored = sample_data_utility.retrieve_financing_statement_record(registration_number)
+    assert stored
+    assert stored.registration_number == registration_number
+    assert stored.registration_type_code == 'SA'
+    assert stored.status == 'A'
+    assert stored.life_in_years == 5
+    assert stored.expiry_date.isoformat() == body['expiryDate']
+    assert stored.last_updated
+
+    assert len(stored.events) == 1
+    assert stored.events[0].registration_number == stored.events[0].base_registration_number == registration_number
+    assert stored.events[0].user_id == 'fake_user_id'  # Default user for integration tests
+    assert stored.events[0].registration_date.isoformat(timespec='seconds') == body['registrationDateTime']

--- a/ppr-api/tests/integration/utilities/sample_data_utility.py
+++ b/ppr-api/tests/integration/utilities/sample_data_utility.py
@@ -1,6 +1,7 @@
 import datetime
 
 import datedelta
+import sqlalchemy.orm
 
 import models.database
 import models.financing_statement
@@ -78,5 +79,14 @@ def retrieve_search_result_records(search_id: int):
     db = models.database.SessionLocal()
     try:
         return db.query(models.search.SearchResult).filter(models.search.SearchResult.search_id == search_id).all()
+    finally:
+        db.close()
+
+
+def retrieve_financing_statement_record(base_reg_number: str):
+    db = models.database.SessionLocal()
+    try:
+        query = db.query(models.financing_statement.FinancingStatement).options(sqlalchemy.orm.joinedload('events'))
+        return query.get(base_reg_number)
     finally:
         db.close()

--- a/ppr-api/tests/unit/repository/test_financing_statement_repository.py
+++ b/ppr-api/tests/unit/repository/test_financing_statement_repository.py
@@ -1,0 +1,95 @@
+import datetime
+from unittest.mock import patch
+
+import freezegun
+
+import auth.authentication
+import repository.financing_statement_repository
+import schemas.financing_statement
+from schemas.financing_statement import RegistrationType
+
+
+@patch('sqlalchemy.orm.Session')
+def test_create_financing_statement_event_registration_and_base_registration_are_same(mock_session):
+    repo = repository.financing_statement_repository.FinancingStatementRepository(mock_session)
+
+    financing_statement = repo.create_financing_statement(stub_financing_statement_input(), stub_user())
+
+    assert financing_statement.registration_number
+    assert len(financing_statement.events) == 1
+    assert financing_statement.registration_number == financing_statement.events[0].registration_number
+
+
+@patch('sqlalchemy.orm.Session')
+def test_create_financing_statement_event_user_is_saved(mock_session):
+    repo = repository.financing_statement_repository.FinancingStatementRepository(mock_session)
+    user = stub_user(user_id='789')
+
+    financing_statement = repo.create_financing_statement(stub_financing_statement_input(), user)
+
+    assert financing_statement.events[0].user_id == '789'
+
+
+@patch('sqlalchemy.orm.Session')
+def test_create_financing_statement_should_not_expire_when_years_not_set(mock_session):
+    repo = repository.financing_statement_repository.FinancingStatementRepository(mock_session)
+    schema = stub_financing_statement_input(years=None)
+
+    financing_statement = repo.create_financing_statement(schema, stub_user())
+
+    assert financing_statement.expiry_date is None
+    assert financing_statement.life_in_years == -1
+
+
+@freezegun.freeze_time('2020-02-29 12:00:00')
+@patch('sqlalchemy.orm.Session')
+def test_create_financing_statement_leap_day_to_non_leap_year_should_expire_in_march(mock_session):
+    repo = repository.financing_statement_repository.FinancingStatementRepository(mock_session)
+    schema = stub_financing_statement_input(years=3)
+
+    financing_statement = repo.create_financing_statement(schema, stub_user())
+
+    assert financing_statement.expiry_date == datetime.date(2023, 3, 1)
+    assert financing_statement.life_in_years == 3
+
+
+@freezegun.freeze_time('2020-02-29 12:00:00')
+@patch('sqlalchemy.orm.Session')
+def test_create_financing_statement_leap_day_to_leap_year_should_expire_on_leap_day(mock_session):
+    repo = repository.financing_statement_repository.FinancingStatementRepository(mock_session)
+    schema = stub_financing_statement_input(years=24)
+
+    financing_statement = repo.create_financing_statement(schema, stub_user())
+
+    assert financing_statement.expiry_date == datetime.date(2044, 2, 29)
+    assert financing_statement.life_in_years == 24
+
+
+@patch('sqlalchemy.orm.Session')
+def test_create_financing_statement_type_code_is_enum_value(mock_session):
+    repo = repository.financing_statement_repository.FinancingStatementRepository(mock_session)
+    schema = stub_financing_statement_input(reg_type=RegistrationType.REPAIRERS_LIEN)
+
+    financing_statement = repo.create_financing_statement(schema, stub_user())
+
+    assert financing_statement.registration_type_code == RegistrationType.REPAIRERS_LIEN.value
+
+
+@patch('sqlalchemy.orm.Session')
+def test_create_financing_statement_status_is_active(mock_session):
+    repo = repository.financing_statement_repository.FinancingStatementRepository(mock_session)
+
+    financing_statement = repo.create_financing_statement(stub_financing_statement_input(), stub_user())
+
+    assert financing_statement.status == 'A'
+
+
+def stub_financing_statement_input(reg_type: RegistrationType = RegistrationType.SECURITY_AGREEMENT, years: int = None):
+    return schemas.financing_statement.FinancingStatementBase(
+        type=reg_type.name, years=years, registeringParty={}, securedParties=[], debtors=[],
+        vehicleCollateral=[], generalCollateral=[]
+    )
+
+
+def stub_user(user_id: str = '12345'):
+    return auth.authentication.User(user_id=user_id, user_name='fred')

--- a/ppr-api/tests/unit/utils/test_datetime.py
+++ b/ppr-api/tests/unit/utils/test_datetime.py
@@ -1,0 +1,29 @@
+import datetime
+
+import freezegun
+
+import utils.datetime
+
+
+@freezegun.freeze_time('2020-02-22 00:00:01', tz_offset=0)
+def test_today_pacific_early_utc_should_resolve_to_pacific_date():
+    today = utils.datetime.today_pacific()
+    assert today == datetime.date(2020, 2, 21)
+
+
+@freezegun.freeze_time('2020-02-22 23:59:59', tz_offset=0)
+def test_today_pacific_late_utc_should_remain_the_same():
+    today = utils.datetime.today_pacific()
+    assert today == datetime.date(2020, 2, 22)
+
+
+@freezegun.freeze_time('2020-02-22 13:00:00', tz_offset=-8)
+def test_today_pacific_early_pst_should_remain_the_same():
+    today = utils.datetime.today_pacific()
+    assert today == datetime.date(2020, 2, 22)
+
+
+@freezegun.freeze_time('2020-02-22 23:59:59', tz_offset=-8)
+def test_today_pacific_late_pst_should_remain_the_same():
+    today = utils.datetime.today_pacific()
+    assert today == datetime.date(2020, 2, 22)


### PR DESCRIPTION
This is the first cut of `POST /financing-statements`.  There is not yet support for registering party and there is no validation to speak of.  These will come in the next commits.
