### PR TITLE
Update the financing statement retrieval so parties that have an ending event are ignored

### DIFF
--- a/ppr-api/src/endpoints/financing_statement.py
+++ b/ppr-api/src/endpoints/financing_statement.py
@@ -36,18 +36,19 @@ def read_financing_statement(base_reg_num: str, fs_repo: FinancingStatementRepos
 
 
 def map_financing_statement_model_to_schema(model: models.financing_statement.FinancingStatement):
-    base_event = next(event for event in model.events if event.registration_number == model.registration_number)
-    reg_party_in = next((p for p in model.parties if p.type_code == schemas.party.PartyType.REGISTERING.value), None)
+    base_event = model.get_base_event()
+    reg_date = base_event.registration_date if base_event else None
+    reg_party_model = model.get_registering_party()
 
-    reg_party_out = schemas.party.Party(
-        name=schemas.party.IndividualName(first=reg_party_in.first_name, middle=reg_party_in.middle_name,
-                                          last=reg_party_in.last_name)
-    ) if reg_party_in else None
+    reg_party_schema = schemas.party.Party(
+        name=schemas.party.IndividualName(first=reg_party_model.first_name, middle=reg_party_model.middle_name,
+                                          last=reg_party_model.last_name)
+    ) if reg_party_model else None
 
     return schemas.financing_statement.FinancingStatement(
-        baseRegistrationNumber=model.registration_number, registrationDateTime=base_event.registration_date,
+        baseRegistrationNumber=model.registration_number, registrationDateTime=reg_date,
         expiryDate=model.expiry_date, years=model.life_in_years if model.life_in_years > 0 else None,
         type=schemas.financing_statement.RegistrationType(model.registration_type_code).name,
-        registeringParty=reg_party_out, securedParties=[], debtors=[],
+        registeringParty=reg_party_schema, securedParties=[], debtors=[],
         vehicleCollateral=[], generalCollateral=[]
     )

--- a/ppr-api/src/schemas/financing_statement.py
+++ b/ppr-api/src/schemas/financing_statement.py
@@ -25,7 +25,7 @@ class FinancingStatementBase(BaseModel):
 class FinancingStatement(FinancingStatementBase):
     baseRegistrationNumber: str
     documentId: str = None
-    registrationDateTime: datetime.datetime
+    registrationDateTime: datetime.datetime = None
     expiryDate: datetime.date = None
 
     class Config:

--- a/ppr-api/tests/integration/api/test_financing_statement.py
+++ b/ppr-api/tests/integration/api/test_financing_statement.py
@@ -31,6 +31,22 @@ def test_read_financing_statement_with_no_expiry():
     assert body['years'] is None
 
 
+def test_read_financing_statement_with_changed_registering_party_should_provide_active_record():
+    fin_stmt = sample_data_utility.create_test_financing_statement(
+        registeringParty={'first_name': 'Homer', 'last_name': 'Simpson'}
+    )
+    fin_stmt = sample_data_utility.create_test_financing_statement_event(
+        fin_stmt, registeringParty={'first_name': 'Charles', 'middle_name': 'Montgomery', 'last_name': 'Burns'}
+    )
+
+    rv = client.get('/financing-statements/{}'.format(fin_stmt.registration_number))
+    body = rv.json()
+
+    assert body['registeringParty']['name']['first'] == 'Charles'
+    assert body['registeringParty']['name']['middle'] == 'Montgomery'
+    assert body['registeringParty']['name']['last'] == 'Burns'
+
+
 def test_create_financing_statement_for_root_object_details():
     request_payload = {
         'type': 'SECURITY_AGREEMENT',

--- a/ppr-api/tests/unit/endpoints/test_financing_statement.py
+++ b/ppr-api/tests/unit/endpoints/test_financing_statement.py
@@ -77,6 +77,17 @@ def test_read_financing_statement_registration_date_taken_from_base_event():
     assert result.registrationDateTime == stub_fs.events[0].registration_date
 
 
+def test_read_financing_statement_registration_is_none_when_base_event_not_present():
+    base_reg_num = '123456C'
+    stub_fs = stub_financing_statement(base_reg_num)
+    stub_fs.events = []
+    repo = MockFinancingStatementRepository(stub_fs)
+
+    result = endpoints.financing_statement.read_financing_statement(base_reg_num, repo)
+
+    assert result.registrationDateTime is None
+
+
 def test_read_financing_statement_registering_party_name_should_be_included():
     base_reg_num = '123456C'
     reg_party = models.party.Party(type_code=PartyType.REGISTERING.value, base_registration_number=base_reg_num,

--- a/ppr-api/tests/unit/models/test_financing_statement_model.py
+++ b/ppr-api/tests/unit/models/test_financing_statement_model.py
@@ -1,0 +1,57 @@
+from models.financing_statement import FinancingStatement, FinancingStatementEvent
+import models.party
+from schemas.party import PartyType
+
+
+def test_get_base_event_should_get_record_with_same_registration_number():
+    base_reg_num = '123456A'
+    model = FinancingStatement(registration_number=base_reg_num, events=[
+        FinancingStatementEvent(registration_number='123457B', base_registration_number=base_reg_num),
+        FinancingStatementEvent(registration_number='123459C', base_registration_number=base_reg_num),
+        FinancingStatementEvent(registration_number=base_reg_num, base_registration_number=base_reg_num),
+        FinancingStatementEvent(registration_number='123458D', base_registration_number=base_reg_num)
+    ])
+
+    event = model.get_base_event()
+
+    assert event.registration_number == base_reg_num
+
+
+def test_get_base_event_should_is_none_when_base_event_missing():
+    # A financing statement without a base event is technically in valid data, but it should not cause an error to occur
+    base_reg_num = '123456A'
+    model = FinancingStatement(registration_number=base_reg_num, events=[
+        FinancingStatementEvent(registration_number='123457B', base_registration_number=base_reg_num),
+        FinancingStatementEvent(registration_number='123459C', base_registration_number=base_reg_num),
+        FinancingStatementEvent(registration_number='123458D', base_registration_number=base_reg_num)
+    ])
+
+    event = model.get_base_event()
+
+    assert event is None
+
+
+def test_get_registering_party_has_registering_type():
+    model = FinancingStatement(parties=[
+        models.party.Party(type_code=PartyType.DEBTOR.value, last_name='Flintstone'),
+        models.party.Party(type_code=PartyType.REGISTERING.value, last_name='Jetson'),
+        models.party.Party(type_code=PartyType.SECURED.value, last_name='Spacely')
+    ])
+
+    reg_party = model.get_registering_party()
+
+    assert reg_party.last_name == 'Jetson'
+
+
+def test_get_registering_party_is_none_when_parties_empty():
+    model = FinancingStatement(parties=[])
+    assert model.get_registering_party() is None
+
+
+def test_get_registering_party_is_none_when_parties_has_no_registering_type():
+    model = FinancingStatement(parties=[
+        models.party.Party(type_code=PartyType.DEBTOR.value, last_name='Flintstone'),
+        models.party.Party(type_code=PartyType.SECURED.value, last_name='Spacely')
+    ])
+
+    assert model.get_registering_party() is None

--- a/ppr-api/tests/unit/repository/test_financing_statement_repository.py
+++ b/ppr-api/tests/unit/repository/test_financing_statement_repository.py
@@ -92,8 +92,7 @@ def test_create_financing_statement_registering_party_is_added_to_financing_stat
 
     financing_statement = repo.create_financing_statement(stub_financing_statement_input(), stub_user())
 
-    fs_reg_party = next(p for p in financing_statement.parties if p.type_code == PartyType.REGISTERING.value)
-    assert fs_reg_party
+    assert financing_statement.get_registering_party()
 
 
 @patch('sqlalchemy.orm.Session')
@@ -115,7 +114,7 @@ def test_create_financing_statement_registering_party_name_is_included(mock_sess
 
     financing_statement = repo.create_financing_statement(schema, stub_user())
 
-    reg_party = next(p for p in financing_statement.parties if p.type_code == PartyType.REGISTERING.value)
+    reg_party = financing_statement.get_registering_party()
     assert reg_party.first_name == 'Homer'
     assert reg_party.middle_name == 'Jay'
     assert reg_party.last_name == 'Simpson'


### PR DESCRIPTION
This change set includes a bit of refactoring to move the logic of determining a registering party and the base event into the model.