### PR TITLE
Temporarily removed payment integration until account based payment is supported

### DIFF
--- a/ppr-api/src/repository/search_repository.py
+++ b/ppr-api/src/repository/search_repository.py
@@ -20,7 +20,8 @@ class SearchRepository:
                       similar_matches: typing.List[str], user: auth.authentication.User,
                       payment: schemas.payment.Payment):
         model = models.search.Search(criteria=search_input.criteria, type_code=search_input.type, user_id=user.user_id)
-        model.payment = models.payment.Payment(id=payment.id, method=payment.method, status=payment.status)
+        if payment:
+            model.payment = models.payment.Payment(id=payment.id, method=payment.method, status=payment.status)
 
         for match in exact_matches:
             model.results.append(models.search.SearchResult(registration_number=match, exact=True, selected=True))

--- a/ppr-api/src/services/payment_service.py
+++ b/ppr-api/src/services/payment_service.py
@@ -7,7 +7,6 @@ import requests
 
 import config
 import auth.authentication
-import schemas.payment
 
 logger = logging.getLogger(__name__)
 
@@ -57,6 +56,9 @@ def create_payment_request(auth_header: HTTPAuthorizationCredentials = Depends(a
     return pay_response.json()
 
 
-def get_payment(api_payment: dict = Depends(create_payment_request)):
-    return schemas.payment.Payment(id=api_payment['id'], status=api_payment['statusCode'],
-                                   method=api_payment['paymentMethod'])
+# TODO #603 Temporarily removed payment integration until account base payment is supported.
+# def get_payment(api_payment: dict = Depends(create_payment_request)):
+#     return schemas.payment.Payment(id=api_payment['id'], status=api_payment['statusCode'],
+#                                    method=api_payment['paymentMethod'])
+def get_payment():
+    return None

--- a/ppr-api/tests/integration/api/test_search.py
+++ b/ppr-api/tests/integration/api/test_search.py
@@ -40,20 +40,21 @@ def test_create_registration_number_search():
     assert body['searchDateTime'] == stored.creation_date_time.isoformat(timespec='seconds')
 
 
-def test_create_search_returns_payment_info():
-    search_input = {'type': 'SERIAL_NUMBER', 'criteria': {'value': 'ABC123456'}}
-
-    rv = client.post('/searches', json=search_input)
-
-    body = rv.json()
-
-    # Ensure default payment info for integration tests is provided.  See ../conftest.py
-    assert 'payment' in body
-    assert body['payment']['status'] == 'CREATED'
-    assert body['payment']['method'] == 'CC'
-
-    stored = sample_data_utility.retrieve_search_record(body['id'])
-    assert body['payment']['id'] == stored.payment_id
+# TODO #603 Temporarily removed payment integration, as it is not currently working in dev
+# def test_create_search_returns_payment_info():
+#     search_input = {'type': 'SERIAL_NUMBER', 'criteria': {'value': 'ABC123456'}}
+#
+#     rv = client.post('/searches', json=search_input)
+#
+#     body = rv.json()
+#
+#     # Ensure default payment info for integration tests is provided.  See ../conftest.py
+#     assert 'payment' in body
+#     assert body['payment']['status'] == 'CREATED'
+#     assert body['payment']['method'] == 'CC'
+#
+#     stored = sample_data_utility.retrieve_search_record(body['id'])
+#     assert body['payment']['id'] == stored.payment_id
 
 
 def test_create_search_with_exact_match():

--- a/ppr-api/tests/unit/services/test_payment_service.py
+++ b/ppr-api/tests/unit/services/test_payment_service.py
@@ -52,11 +52,12 @@ def test_create_payment_request_with_unexpected_response(mock_post):
         pytest.fail('A general error was expected since the payment api returned an unexpected response')
 
 
-def test_get_current_user():
-    api_response = {'id': 1234, 'paymentMethod': 'CC', 'statusCode': 'CREATED'}
-
-    payment = services.payment_service.get_payment(api_response)
-
-    assert payment.id == 1234
-    assert payment.status == 'CREATED'
-    assert payment.method == 'CC'
+# TODO #603 Temporarily removed payment integration until account base payment is supported.
+# def test_get_current_user():
+#     api_response = {'id': 1234, 'paymentMethod': 'CC', 'statusCode': 'CREATED'}
+#
+#     payment = services.payment_service.get_current_user(api_response)
+#
+#     assert payment.id == 1234
+#     assert payment.status == 'CREATED'
+#     assert payment.method == 'CC'


### PR DESCRIPTION
We've been using a hard-coded payload to payments based on the legal api to integrate with payments.  This is no longer working as we are getting back a FORBIDDEN response indicating that the user does not have permission to use the resource.

The relationships team is working on improvements to the Payment API that will better support our needs and leverage the user's account.

Rather than trying to further shoe-horn the current state to work with our system, I've temporarily commented out the integration with the payments API. 