### PR TITLE
Added more fields to the Financing Statement

### DIFF
--- a/ppr-ui/src/financing-statement/FinancingStatement.vue
+++ b/ppr-ui/src/financing-statement/FinancingStatement.vue
@@ -12,7 +12,7 @@
             @input="updateType"
           />
           <v-text-field
-            :value="value.life"
+            :value="value.years"
             :rules="lifeRules"
             label="Life in Years"
             name="lifeInput"
@@ -21,10 +21,16 @@
         </div>
         <div v-else>
           <div>
+            Base Registration Number: {{ value.baseRegistrationNumber }}
+          </div>
+          <div>
+            Expiry Date: {{ value.expiryDate }}
+          </div>
+          <div>
             Type: {{ value.type }}
           </div>
           <div>
-            Life in Years: {{ value.life }}
+            Life in Years: {{ value.years }}
           </div>
         </div>
       </v-container>
@@ -74,7 +80,7 @@ export default createComponent({
         return !!value || 'Life is required'
       },
       (value: string): (boolean | string) => {
-        return FinancingStatementModel.isValidLife(value) ? true : 'Life must be a number between 1 and 25'
+        return FinancingStatementModel.isValidYears(value) ? true : 'Life must be a number between 1 and 25'
       }
     ]
 
@@ -97,7 +103,7 @@ export default createComponent({
     function updateRegisteringParty(newPerson: PersonModel): void {
       emit('input', new FinancingStatementModel(
         props.value.type,
-        props.value.life,
+        props.value.years,
         newPerson // props.value.registeringParty
       ))
     }
@@ -110,11 +116,11 @@ export default createComponent({
         props.value.registeringParty))
     }
 
-    // Callback function for emitting model changes made to the FS life
+    // Callback function for emitting model changes made to the FS type
     function updateType(newType: FinancingStatementType): void {
       emit('input', new FinancingStatementModel(
         newType, //props.value.type,
-        props.value.life,
+        props.value.years,
         props.value.registeringParty))
     }
 

--- a/ppr-ui/src/financing-statement/financing-statement-model.ts
+++ b/ppr-ui/src/financing-statement/financing-statement-model.ts
@@ -5,35 +5,78 @@ import { FinancingStatementType } from '@/financing-statement/financing-statemen
  * The interface to a financing statement.
  */
 export interface FinancingStatementInterface {
-  securedParties: [];
+  baseRegistrationNumber: string | undefined;
   debtors: [];
-  vehicleCollateral: [];
+  expiryDate: string | undefined;
   generalCollateral: [];
-  type: FinancingStatementType;
-  years: number;
   registeringParty: PersonInterface;
+  registrationDateTime: string | undefined;
+  securedParties: [];
+  type: FinancingStatementType;
+  vehicleCollateral: [];
+  years: number;
 }
 
 export class FinancingStatementModel {
-  private _type: FinancingStatementType
-  private _life: number
+  private _baseRegistrationNumber: string | undefined
+  private _expiryDate: string | undefined
   private _registeringParty: PersonModel
+  private _registrationDateTime: string | undefined
+  private _type: FinancingStatementType
+  private _years: number
 
   /**
    * Creates a new FinancingStatementModel model instance.
    *
    * @param type the type of financing statement. A value from the FinancingStatementType enum
-   * @param life the number of years the financing statement is registered for. A value between 1 and 25.
+   * @param years the number of years the financing statement is registered for. A value between 1 and 25.
    * @param registeringParty the PersonModel who registered the financing statement
+   * @param baseRegistrationNumber the unique registration number for the financing statement, may be undefined.
+   * @param registrationDateTime the date and time that the financing statement was registered.
+   * @param expiryDate the expiry date of the financing statement.
    */
   public constructor(
     type: FinancingStatementType = FinancingStatementType.SECURITY_AGREEMENT,
-    life: number = 1,
-    registeringParty: PersonModel = new PersonModel()
+    years: number = 1,
+    registeringParty: PersonModel = new PersonModel(),
+    baseRegistrationNumber?: string,
+    registrationDatetime?: string,
+    expiryDate?: string
   ) {
     this._type = type
-    this._life = life
+    this._years = years
     this._registeringParty = registeringParty
+    this._baseRegistrationNumber = baseRegistrationNumber
+    this._registrationDateTime = registrationDatetime
+    this._expiryDate = expiryDate
+  }
+
+  /**
+   * Gets the unique registration number for the financing statement.
+   */
+  public get baseRegistrationNumber(): string | undefined {
+    return this._baseRegistrationNumber
+  }
+
+  /**
+   * Gets the expiry date of the financing statement.
+   */
+  public get expiryDate(): string | undefined {
+    return this._expiryDate
+  }
+
+  /**
+   * Gets the Person who registered the financing statement
+   */
+  public get registeringParty(): PersonModel {
+    return this._registeringParty
+  }
+
+  /**
+   * Gets the date and time that the financing statement was registered.
+   */
+  public get registrationDateTime(): string | undefined {
+    return this._registrationDateTime
   }
 
   /**
@@ -46,15 +89,8 @@ export class FinancingStatementModel {
   /**
    * Gets the number of years the financing statement is registered for.
    */
-  public get life(): number {
-    return this._life
-  }
-
-  /**
-   * Gets the Person who registered the financing statement
-   */
-  public get registeringParty(): PersonModel {
-    return this._registeringParty
+  public get years(): number {
+    return this._years
   }
 
   /**
@@ -62,13 +98,16 @@ export class FinancingStatementModel {
    */
   public toJson(): FinancingStatementInterface {
     return {
-      securedParties: [],
+      baseRegistrationNumber: this.baseRegistrationNumber,
       debtors: [],
-      vehicleCollateral: [],
+      expiryDate: this.expiryDate,
       generalCollateral: [],
+      registeringParty: this.registeringParty.toJson(),
+      registrationDateTime: this.registrationDateTime,
+      securedParties: [],
       type: this.type,
-      years: this.life,
-      registeringParty: this.registeringParty.toJson()
+      vehicleCollateral: [],
+      years: this.years
     }
   }
 
@@ -77,11 +116,11 @@ export class FinancingStatementModel {
    */
 
   /**
-  * Helper function to validate the life of a financing statement given a string value from an input field.
-  *
-  * @param value string from a form input
-  */
-  public static isValidLife(value: string): string | boolean {
+   * Helper function to validate the life of a financing statement given a string value from an input field.
+   *
+   * @param value string from a form input
+   */
+  public static isValidYears(value: string): string | boolean {
     let isValid = false
     const parsed = Number.parseInt(value)
     if (!Number.isNaN(parsed)) {
@@ -112,7 +151,10 @@ export class FinancingStatementModel {
     return new FinancingStatementModel(
       jsonObject.type,
       jsonObject.years,
-      registeringParty
+      registeringParty,
+      jsonObject.baseRegistrationNumber,
+      jsonObject.registrationDateTime,
+      jsonObject.expiryDate
     )
   }
 }

--- a/ppr-ui/tests/unit/financing-statement/FinancingStatement.spec.ts
+++ b/ppr-ui/tests/unit/financing-statement/FinancingStatement.spec.ts
@@ -6,6 +6,7 @@ import Vuetify from 'vuetify'
 import FinancingStatement from '@/financing-statement/FinancingStatement.vue'
 import { FinancingStatementModel } from '@/financing-statement/financing-statement-model'
 import { FinancingStatementType } from '@/financing-statement/financing-statement-type'
+import { PersonModel } from '@/components/person-model'
 
 Vue.use(Vuetify)
 Vue.use(VueCompositionApi)
@@ -49,7 +50,6 @@ describe('FinancingStatmentContainer.vue', (): void => {
       // expect(emitted.type).toBe(FinancingStatementType.REPAIRERS_LIEN)
     })
 
-
     it('@input - life change should be emitted', async (): Promise<void> => {
       const properties = ref({ editing: true, value: new FinancingStatementModel() })
       const wrapper: Wrapper<Vue> = mount(FinancingStatement, { propsData: properties.value, vuetify })
@@ -58,9 +58,8 @@ describe('FinancingStatmentContainer.vue', (): void => {
       await Vue.nextTick()
 
       const emitted = wrapper.emitted('input').slice(-1)[0][0]
-      expect(emitted.life).toBe('22')
+      expect(emitted.years).toBe('22')
     })
-
 
     it('@valid - invalid life should be false', async (): Promise<void> => {
       const properties = ref({ editing: true, value: new FinancingStatementModel() })
@@ -71,6 +70,28 @@ describe('FinancingStatmentContainer.vue', (): void => {
 
       expect(wrapper.emitted('valid').slice(-1)[0][0]).toBeFalsy()
     })
-  })
 
+    it('@valid - valid data to emit valid true', async (): Promise<void> => {
+      const financingStatement = new FinancingStatementModel(FinancingStatementType.SECURITY_AGREEMENT, 13,
+        new PersonModel('first', 'middle', 'last'))
+      const properties = ref({ editing: true, value: financingStatement })
+      const wrapper: Wrapper<Vue> = mount(FinancingStatement, { propsData: properties.value, vuetify })
+
+      expect(wrapper.emitted('valid').slice(-1)[0][0]).toBeTruthy()
+    })
+
+    it('@valid - missing registering party name to emit valid false', async (): Promise<void> => {
+      const financingStatement = new FinancingStatementModel(FinancingStatementType.SECURITY_AGREEMENT, 13,
+        new PersonModel('first', 'middle', 'last'))
+      const properties = ref({ editing: true, value: financingStatement })
+      const wrapper: Wrapper<Vue> = mount(FinancingStatement, { propsData: properties.value, vuetify })
+
+      // Needed a double nextTick, probably due to the emits from two components.
+      wrapper.get('input[data-test-id="BaseParty.firstName"]').setValue('')
+      await Vue.nextTick()
+      await Vue.nextTick()
+
+      expect(wrapper.emitted('valid').slice(-1)[0][0]).toBeFalsy()
+    })
+  })
 })

--- a/ppr-ui/tests/unit/financing-statement/financing-statement.spec.ts
+++ b/ppr-ui/tests/unit/financing-statement/financing-statement.spec.ts
@@ -4,9 +4,9 @@ import { PersonModel } from '@/components/person-model'
 
 describe('FinancingStatementModel', (): void => {
 
-  describe('FinancingStatementModel.isValidLife', (): void => {
+  describe('FinancingStatementModel.isValidYears', (): void => {
     function test(input: string, expected: boolean): void {
-      const isValid = FinancingStatementModel.isValidLife(input)
+      const isValid = FinancingStatementModel.isValidYears(input)
       expect(isValid).toBe(expected)
     }
 
@@ -37,8 +37,6 @@ describe('FinancingStatementModel', (): void => {
     it('life PI is not valid', (): void => {
       test('3.14159', false)
     })
-
-
   })
 
   describe('construction', (): void => {
@@ -47,7 +45,7 @@ describe('FinancingStatementModel', (): void => {
       const testPerson = new PersonModel()
 
       expect(fstmt.type).toEqual(FinancingStatementType.SECURITY_AGREEMENT)
-      expect(fstmt.life).toEqual(1)
+      expect(fstmt.years).toEqual(1)
       expect(fstmt.registeringParty.firstName).toEqual(testPerson.firstName)
       expect(fstmt.registeringParty.middleName).toEqual(testPerson.middleName)
       expect(fstmt.registeringParty.lastName).toEqual(testPerson.lastName)
@@ -58,7 +56,7 @@ describe('FinancingStatementModel', (): void => {
       const testPerson = new PersonModel()
 
       expect(fstmt.type).toEqual(FinancingStatementType.SECURITY_AGREEMENT)
-      expect(fstmt.life).toEqual(2)
+      expect(fstmt.years).toEqual(2)
       expect(fstmt.registeringParty.firstName).toEqual(testPerson.firstName)
       expect(fstmt.registeringParty.middleName).toEqual(testPerson.middleName)
       expect(fstmt.registeringParty.lastName).toEqual(testPerson.lastName)
@@ -69,7 +67,7 @@ describe('FinancingStatementModel', (): void => {
       const testPerson = new PersonModel()
 
       expect(fstmt.type).toEqual(FinancingStatementType.REPAIRERS_LIEN)
-      expect(fstmt.life).toEqual(1)
+      expect(fstmt.years).toEqual(1)
       expect(fstmt.registeringParty.firstName).toEqual(testPerson.firstName)
       expect(fstmt.registeringParty.middleName).toEqual(testPerson.middleName)
       expect(fstmt.registeringParty.lastName).toEqual(testPerson.lastName)
@@ -80,10 +78,28 @@ describe('FinancingStatementModel', (): void => {
       const fstmt = new FinancingStatementModel(undefined, undefined, testPerson)
 
       expect(fstmt.type).toEqual(FinancingStatementType.SECURITY_AGREEMENT)
-      expect(fstmt.life).toEqual(1)
+      expect(fstmt.years).toEqual(1)
       expect(fstmt.registeringParty.firstName).toEqual(testPerson.firstName)
       expect(fstmt.registeringParty.middleName).toEqual(testPerson.middleName)
       expect(fstmt.registeringParty.lastName).toEqual(testPerson.lastName)
+    })
+
+    it('construct with base registration number', (): void => {
+      const fstmt = new FinancingStatementModel(undefined, undefined, undefined, '123456A')
+
+      expect(fstmt.baseRegistrationNumber).toEqual('123456A')
+    })
+
+    it('construct with registration date and time', (): void => {
+      const fstmt = new FinancingStatementModel(undefined, undefined, undefined, undefined, '2020-01-01T01:01:01')
+
+      expect(fstmt.registrationDateTime).toEqual('2020-01-01T01:01:01')
+    })
+
+    it('construct with expiry date', (): void => {
+      const fstmt = new FinancingStatementModel(undefined, undefined, undefined, undefined, undefined, '2030-01-01')
+
+      expect(fstmt.expiryDate).toEqual('2030-01-01')
     })
   })
 


### PR DESCRIPTION
- Standardized on "years" rather than "life", except for display. Will mirror the API and follow if changes happen there.
- Added base registration number, registration date time, and expiry date
- Now doing readonly display of base registration number and expiry date.
- Not displaying registration date time until we decide how to handle UTC.
- Added tests for new code, plus some to bring up coverage a bit.