### PR TITLE
Add some additional linting libraries for python

### DIFF
--- a/.github/workflows/compile-and-test-stage.yml
+++ b/.github/workflows/compile-and-test-stage.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Lint Python Source
         working-directory: ppr-api
         run: |
-          pylint -E --disable=E0213 src
+          pylint -E src
           pylint -E --disable=E1101 migrations
           flake8 src migrations tests *.py
       - name: Execute Unit Tests with PyTest

--- a/.github/workflows/compile-and-test-stage.yml
+++ b/.github/workflows/compile-and-test-stage.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Lint Python Source
         working-directory: ppr-api
         run: |
-          pylint -E src
+          pylint -E --disable=E0213 src
           pylint -E --disable=E1101 migrations
           flake8 src migrations tests *.py
       - name: Execute Unit Tests with PyTest

--- a/ppr-api/requirements/dev.txt
+++ b/ppr-api/requirements/dev.txt
@@ -1,11 +1,14 @@
 
 -r ../requirements.txt
 
-autopep8
+autopep8==1.5
 fastapi==0.42.0 # version tied to https://github.com/tiangolo/uvicorn-gunicorn-fastapi-docker
 flake8==3.7.9
+flake8-blind-except==0.1.1
+flake8-debugger==3.2.1
 flake8-quotes==2.1.1
 freezegun==0.3.15
+pep8-naming==0.9.1
 pylint==2.4.3
 pytest==5.2.2
 pytest-cov==2.8.1

--- a/ppr-api/src/schemas/search.py
+++ b/ppr-api/src/schemas/search.py
@@ -26,7 +26,7 @@ class SearchBase(pydantic.BaseModel):
     criteria: dict
 
     @pydantic.validator('type')
-    def type_must_match_search_type(cls, search_type):  # noqa: N805
+    def type_must_match_search_type(cls, search_type):  # pylint:disable=no-self-argument # noqa: N805
         try:
             SearchType[search_type]
         except KeyError:
@@ -34,7 +34,7 @@ class SearchBase(pydantic.BaseModel):
         return search_type
 
     @pydantic.validator('criteria')
-    def criteria_must_match_format_for_type(cls, criteria, values):  # noqa: N805
+    def criteria_must_match_format_for_type(cls, criteria, values):  # pylint:disable=no-self-argument # noqa: N805
         if 'type' not in values:
             return criteria
 
@@ -79,7 +79,7 @@ class SearchResult(pydantic.BaseModel):
     financingStatement: schemas.financing_statement.FinancingStatement = None
 
     @pydantic.validator('type')
-    def type_must_match_search_result_type(cls, value):  # noqa: N805
+    def type_must_match_search_result_type(cls, value):  # pylint:disable=no-self-argument # noqa: N805
         try:
             SearchResultType[value]
         except KeyError:

--- a/ppr-api/src/schemas/search.py
+++ b/ppr-api/src/schemas/search.py
@@ -26,7 +26,7 @@ class SearchBase(pydantic.BaseModel):
     criteria: dict
 
     @pydantic.validator('type')
-    def type_must_match_search_type(cls, search_type):  # pylint:disable=no-self-argument
+    def type_must_match_search_type(cls, search_type):  # noqa: N805
         try:
             SearchType[search_type]
         except KeyError:
@@ -34,7 +34,7 @@ class SearchBase(pydantic.BaseModel):
         return search_type
 
     @pydantic.validator('criteria')
-    def criteria_must_match_format_for_type(cls, criteria, values):  # pylint:disable=no-self-argument
+    def criteria_must_match_format_for_type(cls, criteria, values):  # noqa: N805
         if 'type' not in values:
             return criteria
 
@@ -79,7 +79,7 @@ class SearchResult(pydantic.BaseModel):
     financingStatement: schemas.financing_statement.FinancingStatement = None
 
     @pydantic.validator('type')
-    def type_must_match_search_result_type(cls, value):  # pylint:disable=no-self-argument
+    def type_must_match_search_result_type(cls, value):  # noqa: N805
         try:
             SearchResultType[value]
         except KeyError:


### PR DESCRIPTION
Include `flake8-blind-except`, `flake8-debugger` and `pep8-naming` libraries, which extend flake8 linting

These are a subset of libraries used by the wider registries teams which required the least amount of change to incorporate.