### PR TITLE
Update API person name implementation to match specification

### DIFF
--- a/ppr-api/src/endpoints/financing_statement.py
+++ b/ppr-api/src/endpoints/financing_statement.py
@@ -41,8 +41,8 @@ def map_financing_statement_model_to_schema(model: models.financing_statement.Fi
     reg_party_model = model.get_registering_party()
 
     reg_party_schema = schemas.party.Party(
-        name=schemas.party.IndividualName(first=reg_party_model.first_name, middle=reg_party_model.middle_name,
-                                          last=reg_party_model.last_name)
+        personName=schemas.party.IndividualName(first=reg_party_model.first_name, middle=reg_party_model.middle_name,
+                                                last=reg_party_model.last_name)
     ) if reg_party_model else None
 
     return schemas.financing_statement.FinancingStatement(

--- a/ppr-api/src/endpoints/search.py
+++ b/ppr-api/src/endpoints/search.py
@@ -109,8 +109,8 @@ def rebuild_financing_statement_to_event(event: models.financing_statement.Finan
 
     reg_party_model = next((p for p in parties_snapshot if p.type_code == PartyType.REGISTERING.value), None)
     reg_party_schema = schemas.party.Party(
-        name=schemas.party.IndividualName(first=reg_party_model.first_name, middle=reg_party_model.middle_name,
-                                          last=reg_party_model.last_name)
+        personName=schemas.party.IndividualName(first=reg_party_model.first_name, middle=reg_party_model.middle_name,
+                                                last=reg_party_model.last_name)
     ) if reg_party_model else None
 
     return schemas.financing_statement.FinancingStatement(

--- a/ppr-api/src/repository/financing_statement_repository.py
+++ b/ppr-api/src/repository/financing_statement_repository.py
@@ -32,8 +32,9 @@ class FinancingStatementRepository:
 
         party_schema = fs_input.registeringParty
         party_model = models.party.Party(type_code=schemas.party.PartyType.REGISTERING.value,
-                                         first_name=party_schema.name.first, middle_name=party_schema.name.middle,
-                                         last_name=party_schema.name.last)
+                                         first_name=party_schema.personName.first,
+                                         middle_name=party_schema.personName.middle,
+                                         last_name=party_schema.personName.last)
 
         model.events.append(event_model)
         model.parties.append(party_model)

--- a/ppr-api/src/schemas/party.py
+++ b/ppr-api/src/schemas/party.py
@@ -16,4 +16,4 @@ class IndividualName(pydantic.BaseModel):
 
 
 class Party(pydantic.BaseModel):
-    name: IndividualName
+    personName: IndividualName

--- a/ppr-api/tests/integration/api/test_financing_statement.py
+++ b/ppr-api/tests/integration/api/test_financing_statement.py
@@ -42,16 +42,16 @@ def test_read_financing_statement_with_changed_registering_party_should_provide_
     rv = client.get('/financing-statements/{}'.format(fin_stmt.registration_number))
     body = rv.json()
 
-    assert body['registeringParty']['name']['first'] == 'Charles'
-    assert body['registeringParty']['name']['middle'] == 'Montgomery'
-    assert body['registeringParty']['name']['last'] == 'Burns'
+    assert body['registeringParty']['personName']['first'] == 'Charles'
+    assert body['registeringParty']['personName']['middle'] == 'Montgomery'
+    assert body['registeringParty']['personName']['last'] == 'Burns'
 
 
 def test_create_financing_statement_for_root_object_details():
     request_payload = {
         'type': 'SECURITY_AGREEMENT',
         'years': 5,
-        'registeringParty': {'name': {'first': 'Homer', 'last': 'Simpson'}},
+        'registeringParty': {'personName': {'first': 'Homer', 'last': 'Simpson'}},
         'securedParties': [],
         'debtors': [],
         'vehicleCollateral': [],
@@ -85,7 +85,7 @@ def test_create_financing_statement_for_root_object_details():
 def test_create_financing_statement_persists_secured_party():
     request_payload = {
         'type': 'SECURITY_AGREEMENT',
-        'registeringParty': {'name': {'first': 'Homer', 'middle': 'Jay', 'last': 'Simpson'}},
+        'registeringParty': {'personName': {'first': 'Homer', 'middle': 'Jay', 'last': 'Simpson'}},
         'securedParties': [],
         'debtors': [],
         'vehicleCollateral': [],
@@ -96,19 +96,19 @@ def test_create_financing_statement_persists_secured_party():
 
     body = rv.json()
     assert 'registeringParty' in body
-    assert 'name' in body['registeringParty']
-    assert body['registeringParty']['name']['first'] == 'Homer'
-    assert body['registeringParty']['name']['middle'] == 'Jay'
-    assert body['registeringParty']['name']['last'] == 'Simpson'
+    assert 'personName' in body['registeringParty']
+    assert body['registeringParty']['personName']['first'] == 'Homer'
+    assert body['registeringParty']['personName']['middle'] == 'Jay'
+    assert body['registeringParty']['personName']['last'] == 'Simpson'
 
     registration_number = body['baseRegistrationNumber']
     stored = sample_data_utility.retrieve_financing_statement_record(registration_number)
     registering_parties = list(filter(lambda party: party.type_code == 'RP', stored.parties))
 
     assert len(registering_parties) == 1
-    assert registering_parties[0].first_name == body['registeringParty']['name']['first']
-    assert registering_parties[0].middle_name == body['registeringParty']['name']['middle']
-    assert registering_parties[0].last_name == body['registeringParty']['name']['last']
+    assert registering_parties[0].first_name == body['registeringParty']['personName']['first']
+    assert registering_parties[0].middle_name == body['registeringParty']['personName']['middle']
+    assert registering_parties[0].last_name == body['registeringParty']['personName']['last']
     assert registering_parties[0].base_registration_number == registration_number
     assert registering_parties[0].starting_registration_number == registration_number
     assert registering_parties[0].ending_registration_number is None

--- a/ppr-api/tests/integration/api/test_search.py
+++ b/ppr-api/tests/integration/api/test_search.py
@@ -127,7 +127,7 @@ def test_search_results_should_provide_party_at_time_of_search():
     rv = client.get('/searches/{}/results'.format(search.id))
     body = rv.json()
 
-    reg_part_name = body[0]['financingStatement']['registeringParty']['name']
+    reg_part_name = body[0]['financingStatement']['registeringParty']['personName']
     assert reg_part_name['first'] == 'Homer'
     assert reg_part_name['middle'] == 'Jay'
     assert reg_part_name['last'] == 'Simpson'

--- a/ppr-api/tests/unit/endpoints/test_financing_statement.py
+++ b/ppr-api/tests/unit/endpoints/test_financing_statement.py
@@ -98,9 +98,9 @@ def test_read_financing_statement_registering_party_name_should_be_included():
 
     result = endpoints.financing_statement.read_financing_statement(base_reg_num, repo)
 
-    assert result.registeringParty.name.first == 'Homer'
-    assert result.registeringParty.name.middle == 'Jay'
-    assert result.registeringParty.name.last == 'Simpson'
+    assert result.registeringParty.personName.first == 'Homer'
+    assert result.registeringParty.personName.middle == 'Jay'
+    assert result.registeringParty.personName.last == 'Simpson'
 
 
 def test_read_financing_statement_registration_party_should_be_none_when_not_present():

--- a/ppr-api/tests/unit/repository/test_financing_statement_repository.py
+++ b/ppr-api/tests/unit/repository/test_financing_statement_repository.py
@@ -121,7 +121,7 @@ def test_create_financing_statement_registering_party_name_is_included(mock_sess
 
 
 def stub_party(first: str = 'Fred', last: str = 'Flintstone', middle: str = None):
-    return schemas.party.Party(name=schemas.party.IndividualName(first=first, last=last, middle=middle))
+    return schemas.party.Party(personName=schemas.party.IndividualName(first=first, last=last, middle=middle))
 
 
 def stub_financing_statement_input(reg_type: RegistrationType = RegistrationType.SECURITY_AGREEMENT, years: int = None,

--- a/ppr-ui/src/components/person-name-model.ts
+++ b/ppr-ui/src/components/person-name-model.ts
@@ -3,7 +3,7 @@
  * The interface to a person name.
  */
 export interface PersonNameInterface {
-  name: {
+  personName: {
     first: string;
     middle: string;
     last: string;
@@ -20,7 +20,7 @@ export class PersonNameModel {
 
   /**
    * Creates a new Person Name model instance.
-   * 
+   *
    * @param first the first name of the person.
    * @param middle the middle name of the person.
    * @param last the last name of the person.
@@ -57,7 +57,7 @@ export class PersonNameModel {
    */
   public toJson(): PersonNameInterface {
     return {
-      name: {
+      personName: {
         first: this.first,
         middle: this.middle,
         last: this.last
@@ -71,13 +71,13 @@ export class PersonNameModel {
 
   /**
    * Gets a PersonNameModel object from a JSON string.
-   * 
+   *
    * @param jsonObject the JSON version of the object.
    */
   public static fromJson(jsonObject: PersonNameInterface): PersonNameModel {
     return new PersonNameModel(
-      jsonObject.name.first,
-      jsonObject.name.middle,
-      jsonObject.name.last)
+      jsonObject.personName.first,
+      jsonObject.personName.middle,
+      jsonObject.personName.last)
   }
 }

--- a/ppr-ui/src/financing-statement/financing-statement-model.ts
+++ b/ppr-ui/src/financing-statement/financing-statement-model.ts
@@ -134,7 +134,7 @@ export class FinancingStatementModel {
 
   /**
    * Gets a FinancingStatementModel object from a JSON object.
-   * 
+   *
    * @param jsonObject the JSON version of the object.
    */
   public static fromJson(jsonObject: FinancingStatementInterface): FinancingStatementModel {
@@ -142,9 +142,9 @@ export class FinancingStatementModel {
 
     if (jsonObject.registeringParty) {
       registeringParty = new PersonNameModel(
-        jsonObject.registeringParty.name.first,
-        jsonObject.registeringParty.name.middle,
-        jsonObject.registeringParty.name.last
+        jsonObject.registeringParty.personName.first,
+        jsonObject.registeringParty.personName.middle,
+        jsonObject.registeringParty.personName.last
       )
     }
 


### PR DESCRIPTION
On the financing statement, renamed `registeringParty.name` to `registeringParty.personName` in the API.  This included correcting the referencing UI component.