### PR TITLE
Add support for debtor details in financing statement reads.  …

### DIFF
--- a/ppr-api/docs/sample_data/create_sample_financing_statements.sql
+++ b/ppr-api/docs/sample_data/create_sample_financing_statements.sql
@@ -11,16 +11,24 @@ INSERT INTO vehicle (base_reg_number, reg_number_start, vehicle_type_cd, mhr_num
     ('123456A', '123456A', 'MH', '123456'),
     ('123456B', '123456B', 'MH', '567890');
 
-INSERT INTO fs_party (party_type_cd, base_reg_num, reg_number_start, reg_number_end, first_name, middle_name, last_name) VALUES
-    ('RP', '123456A', '123456A', null, 'Homer', 'Jay', 'Simpson'),
-    ('RP', '123456B', '123456B', '123456Z', 'Homer', 'Jay', 'Simpson'),
-    ('DE', '123456B', '123456B', '123456Z', 'George', null, 'Jetson'),
-    ('SP', '123456B', '123456B', null, 'Charles', 'Montgomery', 'Burns'),
-    ('RP', '123456B', '123456Z', null, 'Flintstone', null, 'Fred'),
-    ('DE', '123456B', '123456Z', null, 'Rubble', null, 'Barney');
-
 INSERT INTO general (base_reg_number, reg_number_start, reg_number_end, description) VALUES
     ('123456A', '123456A', null, 'An original description of general collateral'),
     ('123456B', '123456B', null, 'An original continual general collateral'),
     ('123456B', '123456B', '123456Z', 'An original general collateral that was removed on a follow-up event'),
-    ('123456B', '123456Z', null, 'A new general collateral that was added on a secondary registration')
+    ('123456B', '123456Z', null, 'A new general collateral that was added on a secondary registration');
+
+INSERT INTO address(addr_id, addr_line_1, addr_line_2, city, province, country_type_cd, postal_cd) VALUES
+    (10000001, '123 Fake Street', 'Suite 100', 'Victoria', 'BC', 'CA', 'V1V 1V1'),
+    (10000002, '742 Evergreen Terrace', null, 'Springfield', 'CA', 'US', '54321'),
+    (10000003, '742 Evergreen Terrace', null, 'Springfield', 'CA', 'US', '54321'),
+    (10000004, '55 Cobblestone Rd', null, 'Bedrock', null, 'GB', 'A1 1AA'),
+    (10000005, '345 Cave Stone Road', 'Apt 405', 'Hollyrock', 'BC', 'CA', 'V2V 2V2'),
+    (10000006, '1000 Mammon Lane', null, 'Springfield', 'BC', 'CA', 'V3V 3V3');
+
+INSERT INTO fs_party (party_type_cd, base_reg_num, reg_number_start, reg_number_end, addr_id, first_name, middle_name, last_name, business_name, birthdate) VALUES
+    ('RP', '123456A', '123456A', null, 10000002, 'Homer', 'Jay', 'Simpson', 'Mr. Plow', null),
+    ('RP', '123456B', '123456B', '123456Z', 10000003, 'Homer', 'Jay', 'Simpson', 'Mr. Plow', null),
+    ('DE', '123456B', '123456B', '123456Z', 10000001, 'George', null, 'Jetson', null, '2000-01-01'),
+    ('SP', '123456B', '123456B', null, 10000006, 'Charles', 'Montgomery', 'Burns', null, null),
+    ('RP', '123456B', '123456Z', null, 10000004, 'Flintstone', null, 'Fred', null, null),
+    ('DE', '123456B', '123456Z', null, 10000005, 'Rubble', null, 'Barney', null, '1900-02-28');

--- a/ppr-api/src/endpoints/financing_statement.py
+++ b/ppr-api/src/endpoints/financing_statement.py
@@ -6,6 +6,7 @@ from starlette import responses, status
 import auth.authentication
 import models.collateral
 import models.financing_statement
+import models.party
 from repository.financing_statement_repository import FinancingStatementRepository
 import schemas.collateral
 import schemas.financing_statement
@@ -42,20 +43,36 @@ def map_financing_statement_model_to_schema(model: models.financing_statement.Fi
     reg_date = base_event.registration_date if base_event else None
     reg_party_model = model.get_registering_party()
 
-    reg_party_schema = schemas.party.Party(
-        personName=schemas.party.IndividualName(first=reg_party_model.first_name, middle=reg_party_model.middle_name,
-                                                last=reg_party_model.last_name)
-    ) if reg_party_model else None
+    reg_party_schema = map_party_model_to_schema(reg_party_model) if reg_party_model else None
+    debtors_schema = list(map(map_party_model_to_schema, model.get_debtors()))
     general_collateral_schema = list(map(map_general_collateral_model_to_schema, model.general_collateral))
 
     return schemas.financing_statement.FinancingStatement(
         baseRegistrationNumber=model.registration_number, registrationDateTime=reg_date,
         expiryDate=model.expiry_date, years=model.life_in_years if model.life_in_years > 0 else None,
         type=schemas.financing_statement.RegistrationType(model.registration_type_code).name,
-        registeringParty=reg_party_schema, securedParties=[], debtors=[],
+        registeringParty=reg_party_schema, securedParties=[], debtors=debtors_schema,
         vehicleCollateral=[], generalCollateral=general_collateral_schema
     )
 
 
 def map_general_collateral_model_to_schema(model: models.collateral.GeneralCollateral):
     return schemas.collateral.GeneralCollateral(description=model.description)
+
+
+def map_party_model_to_schema(model: models.party.Party):
+    base_args = {
+        'businessName': model.business_name,
+        'personName': schemas.party.IndividualName(
+            first=model.first_name, middle=model.middle_name, last=model.last_name
+        ),
+        'address': schemas.party.Address(
+            street=model.address.line1, streetAdditional=model.address.line2, city=model.address.city,
+            region=model.address.region, country=model.address.country, postalCode=model.address.postal_code
+        ) if model.address else None
+    }
+
+    if model.type_code in [schemas.party.PartyType.REGISTERING.value, schemas.party.PartyType.SECURED.value]:
+        return schemas.party.Party(**base_args)
+    else:  # model.type_code == schemas.party.PartyType.DEBTOR.value
+        return schemas.party.Debtor(birthdate=model.birthdate, **base_args)

--- a/ppr-api/src/models/collateral.py
+++ b/ppr-api/src/models/collateral.py
@@ -1,5 +1,4 @@
 import sqlalchemy
-from sqlalchemy.dialects import postgresql
 
 from .database import BaseORM
 
@@ -14,4 +13,4 @@ class GeneralCollateral(BaseORM):
                                                      sqlalchemy.ForeignKey('registration.reg_number'))
     ending_registration_number = sqlalchemy.Column('reg_number_end', sqlalchemy.String(length=10),
                                                    sqlalchemy.ForeignKey('registration.reg_number'))
-    description = sqlalchemy.Column(postgresql.TEXT)
+    description = sqlalchemy.Column(sqlalchemy.String)

--- a/ppr-api/src/models/financing_statement.py
+++ b/ppr-api/src/models/financing_statement.py
@@ -1,5 +1,4 @@
 import sqlalchemy
-from sqlalchemy.dialects import postgresql
 import sqlalchemy.orm
 
 from .database import BaseORM
@@ -35,6 +34,9 @@ class FinancingStatement(BaseORM):
     def get_base_event(self):
         return next((e for e in self.events if e.registration_number == self.registration_number), None)
 
+    def get_debtors(self):
+        return list(filter(lambda p: p.type_code == PartyType.DEBTOR.value, self.parties))
+
     def get_registering_party(self):
         return next((p for p in self.parties if p.type_code == PartyType.REGISTERING.value), None)
 
@@ -47,7 +49,7 @@ class FinancingStatementEvent(BaseORM):
                                                  sqlalchemy.ForeignKey('financing_statement.reg_number'))
     change_type_code = sqlalchemy.Column('change_type_cd', sqlalchemy.CHAR(length=2))
     registration_date = sqlalchemy.Column('reg_date', sqlalchemy.DateTime, server_default=sqlalchemy.func.now())
-    description = sqlalchemy.Column(postgresql.TEXT)
+    description = sqlalchemy.Column(sqlalchemy.String)
     document_number = sqlalchemy.Column(sqlalchemy.String(length=8))
     user_id = sqlalchemy.Column(sqlalchemy.String(length=36))
 

--- a/ppr-api/src/models/party.py
+++ b/ppr-api/src/models/party.py
@@ -1,5 +1,5 @@
 import sqlalchemy
-from sqlalchemy.dialects import postgresql
+import sqlalchemy.orm
 
 from .database import BaseORM
 
@@ -15,6 +15,24 @@ class Party(BaseORM):
                                                      sqlalchemy.ForeignKey('registration.reg_number'))
     ending_registration_number = sqlalchemy.Column('reg_number_end', sqlalchemy.String(length=10),
                                                    sqlalchemy.ForeignKey('registration.reg_number'))
-    last_name = sqlalchemy.Column(postgresql.TEXT)
-    first_name = sqlalchemy.Column(postgresql.TEXT)
-    middle_name = sqlalchemy.Column(postgresql.TEXT)
+    address_id = sqlalchemy.Column('addr_id', sqlalchemy.BigInteger, sqlalchemy.ForeignKey('address.addr_id'))
+    business_name = sqlalchemy.Column(sqlalchemy.String)
+    last_name = sqlalchemy.Column(sqlalchemy.String)
+    first_name = sqlalchemy.Column(sqlalchemy.String)
+    middle_name = sqlalchemy.Column(sqlalchemy.String)
+    birthdate = sqlalchemy.Column(sqlalchemy.Date)
+
+    address = sqlalchemy.orm.relationship('Address')
+
+
+class Address(BaseORM):
+    __tablename__ = 'address'
+
+    id = sqlalchemy.Column('addr_id', sqlalchemy.BigInteger, primary_key=True)
+    line1 = sqlalchemy.Column('addr_line_1', sqlalchemy.String)
+    line2 = sqlalchemy.Column('addr_line_2', sqlalchemy.String)
+
+    city = sqlalchemy.Column(sqlalchemy.String)
+    region = sqlalchemy.Column('province', sqlalchemy.CHAR(length=2))
+    country = sqlalchemy.Column('country_type_cd', sqlalchemy.CHAR(length=2))
+    postal_code = sqlalchemy.Column('postal_cd', sqlalchemy.String)

--- a/ppr-api/src/models/payment.py
+++ b/ppr-api/src/models/payment.py
@@ -1,5 +1,4 @@
 import sqlalchemy
-from sqlalchemy.dialects import postgresql
 
 from .database import BaseORM
 
@@ -8,5 +7,5 @@ class Payment(BaseORM):
     __tablename__ = 'payment'
 
     id = sqlalchemy.Column(sqlalchemy.BigInteger, primary_key=True)
-    status = sqlalchemy.Column(postgresql.TEXT)
-    method = sqlalchemy.Column(postgresql.TEXT)
+    status = sqlalchemy.Column(sqlalchemy.String)
+    method = sqlalchemy.Column(sqlalchemy.String)

--- a/ppr-api/src/schemas/financing_statement.py
+++ b/ppr-api/src/schemas/financing_statement.py
@@ -18,7 +18,7 @@ class FinancingStatementBase(pydantic.BaseModel):
     years: int = None
     registeringParty: schemas.party.Party = None
     securedParties: typing.List[schemas.party.Party]
-    debtors: typing.List[schemas.party.Party]
+    debtors: typing.List[schemas.party.Debtor]
     vehicleCollateral: typing.List[dict]
     generalCollateral: typing.List[schemas.collateral.GeneralCollateral]
 

--- a/ppr-api/src/schemas/party.py
+++ b/ppr-api/src/schemas/party.py
@@ -1,3 +1,4 @@
+import datetime
 import enum
 
 import pydantic
@@ -15,5 +16,20 @@ class IndividualName(pydantic.BaseModel):
     last: str
 
 
+class Address(pydantic.BaseModel):
+    street: str
+    streetAdditional: str = None
+    city: str
+    region: str = None
+    country: str
+    postalCode: str
+
+
 class Party(pydantic.BaseModel):
-    personName: IndividualName
+    personName: IndividualName = None
+    businessName: str = None
+    address: Address = None
+
+
+class Debtor(Party):
+    birthdate: datetime.date = None

--- a/ppr-api/tests/integration/api/test_financing_statement.py
+++ b/ppr-api/tests/integration/api/test_financing_statement.py
@@ -1,3 +1,5 @@
+import datetime
+
 from starlette.testclient import TestClient
 
 import main
@@ -45,6 +47,33 @@ def test_read_financing_statement_with_changed_registering_party_should_provide_
     assert body['registeringParty']['personName']['first'] == 'Charles'
     assert body['registeringParty']['personName']['middle'] == 'Montgomery'
     assert body['registeringParty']['personName']['last'] == 'Burns'
+
+
+def test_read_financing_statement_registering_party_details():
+    fin_stmt = sample_data_utility.create_test_financing_statement(
+        debtors=[{
+            'first_name': 'Homer', 'middle_name': 'Jay', 'last_name': 'Simpson', 'business_name': 'Mr. Plow',
+            'birthdate': datetime.date(1990, 6, 15),
+            'address': {'line1': '742 Evergreen Terrace', 'line2': '1st floor', 'city': 'Springfield',
+                        'region': 'BC', 'country': 'CA', 'postal_code': 'V1A 1A1'}
+        }]
+    )
+
+    rv = client.get('/financing-statements/{}'.format(fin_stmt.registration_number))
+    body = rv.json()
+
+    assert len(body['debtors']) == 1
+    assert body['debtors'][0]['businessName'] == 'Mr. Plow'
+    assert body['debtors'][0]['personName']['first'] == 'Homer'
+    assert body['debtors'][0]['personName']['middle'] == 'Jay'
+    assert body['debtors'][0]['personName']['last'] == 'Simpson'
+    assert body['debtors'][0]['address']['street'] == '742 Evergreen Terrace'
+    assert body['debtors'][0]['address']['streetAdditional'] == '1st floor'
+    assert body['debtors'][0]['address']['city'] == 'Springfield'
+    assert body['debtors'][0]['address']['region'] == 'BC'
+    assert body['debtors'][0]['address']['country'] == 'CA'
+    assert body['debtors'][0]['address']['postalCode'] == 'V1A 1A1'
+    assert body['debtors'][0]['birthdate'] == '1990-06-15'
 
 
 def test_read_financing_statement_with_changed_general_collateral_should_provide_active_record():

--- a/ppr-api/tests/unit/models/test_financing_statement_model.py
+++ b/ppr-api/tests/unit/models/test_financing_statement_model.py
@@ -17,7 +17,7 @@ def test_get_base_event_should_get_record_with_same_registration_number():
     assert event.registration_number == base_reg_num
 
 
-def test_get_base_event_should_is_none_when_base_event_missing():
+def test_get_base_event_is_none_when_base_event_missing():
     # A financing statement without a base event is technically in valid data, but it should not cause an error to occur
     base_reg_num = '123456A'
     model = FinancingStatement(registration_number=base_reg_num, events=[
@@ -55,3 +55,29 @@ def test_get_registering_party_is_none_when_parties_has_no_registering_type():
     ])
 
     assert model.get_registering_party() is None
+
+
+def test_get_debtors_returns_parties_with_debtor_type():
+    model = FinancingStatement(parties=[
+        models.party.Party(type_code=PartyType.DEBTOR.value, last_name='Flintstone'),
+        models.party.Party(type_code=PartyType.REGISTERING.value, last_name='Jetson'),
+        models.party.Party(type_code=PartyType.DEBTOR.value, last_name='Rubble'),
+        models.party.Party(type_code=PartyType.SECURED.value, last_name='Spacely')
+    ])
+
+    debtors = model.get_debtors()
+
+    assert len(debtors) == 2
+    assert next(d for d in debtors if d.last_name == 'Flintstone')
+    assert next(d for d in debtors if d.last_name == 'Rubble')
+
+
+def test_get_debtors_is_empty_when_no_debtors():
+    model = FinancingStatement(parties=[
+        models.party.Party(type_code=PartyType.REGISTERING.value, last_name='Jetson'),
+        models.party.Party(type_code=PartyType.SECURED.value, last_name='Spacely')
+    ])
+
+    debtors = model.get_debtors()
+
+    assert debtors == []


### PR DESCRIPTION
This feature includes address and business for both debtors and registering parties.  Additionally, there is support for birthdate on debtors.

While making this change, there was a cleanup task to remove references to the postgres specific 'TEXT' field in the main application source.