### PR TITLE
Issue #769 PPR List item

### DIFF
--- a/ppr-ui/src/components/PprListItem.vue
+++ b/ppr-ui/src/components/PprListItem.vue
@@ -1,0 +1,99 @@
+<template>
+  <v-list-item
+    three-line
+    class="ppr-list-item"
+  >
+    <v-list-item-content>
+      <v-list-item-title
+        v-if="editing"
+        data-test-id="ListItem.header.title"
+        class="header"
+      >
+        <v-container>
+          <v-row no-gutters>
+            <v-col
+              md10
+              class="header-content"
+            >
+              <slot name="header" />
+            </v-col>
+            <v-col
+              md2
+              class="item-title"
+              title="Remove"
+            >
+              <v-btn
+                v-if="listLength >= 2"
+                data-test-id="ListItem.button.remove"
+                icon
+                color="red"
+                @click="remove(index)"
+              >
+                <v-icon>mdi-close-circle-outline</v-icon>
+              </v-btn>
+            </v-col>
+          </v-row>
+        </v-container>
+      </v-list-item-title>
+      <v-container class="item-content">
+        <slot />
+      </v-container>
+    </v-list-item-content>
+  </v-list-item>
+</template>
+
+<script lang="ts">
+import { createComponent } from '@vue/composition-api'
+
+export default createComponent({
+  props: {
+    editing: {
+      default: false,
+      required: false,
+      type: Boolean
+    },
+    listLength: {
+      required: true,
+      type: Number
+    },
+    index: {
+      required: true,
+      type: Number
+    }
+  },
+
+  setup(_, { emit }) {
+
+    function remove(index: number): void {
+      emit('remove', index)
+    }
+
+    return {
+      remove
+    }
+  }
+})
+
+</script>
+
+<style lang="scss" scoped>
+.header {
+  padding-left: 1rem;
+}
+.header-content {
+  padding-top: 1.5rem;
+}
+.item-content {
+  margin-top: 0;
+  padding-top: 0;
+}
+
+.v-list-item__content {
+  padding-top: 0;
+}
+.item-title {
+  justify-content: flex-end;
+  margin-left: auto;
+  flex: 0 1 10%;
+}
+</style>

--- a/ppr-ui/tests/unit/components/PprListItem.spec.ts
+++ b/ppr-ui/tests/unit/components/PprListItem.spec.ts
@@ -1,0 +1,62 @@
+import Vue from 'vue'
+import VueCompositionApi, { ref } from '@vue/composition-api'
+import { mount, Wrapper } from '@vue/test-utils'
+import Vuetify from 'vuetify'
+
+import PprListItem from '@/components/PprListItem.vue'
+
+Vue.use(Vuetify)
+Vue.use(VueCompositionApi)
+const vuetify = new Vuetify()
+
+describe('PprListItem.vue', (): void => {
+  describe(':props', (): void => {
+
+    // General form tests.
+
+    it(':editing - true, header exist', (): void => {
+      const properties = ref({ editing: true, listLength: 1, index: 0 })
+      const wrapper: Wrapper<Vue> = mount(PprListItem, { propsData: properties.value, vuetify })
+
+      expect(wrapper.find('div[data-test-id="ListItem.header.title"]').exists()).toBeTruthy()
+    })
+
+    it(':editing - true, list of 0 does not have remove ', (): void => {
+      const properties = ref({ editing: true, listLength: 0, index: 0 })
+      const wrapper: Wrapper<Vue> = mount(PprListItem, { propsData: properties.value, vuetify })
+
+      expect(wrapper.find('button[data-test-id="ListItem.button.remove"]').exists()).toBeFalsy()
+    })
+
+    it(':editing - true, list of 1 does not have remove ', (): void => {
+      const properties = ref({ editing: true, listLength: 1, index: 0 })
+      const wrapper: Wrapper<Vue> = mount(PprListItem, { propsData: properties.value, vuetify })
+
+      expect(wrapper.find('button[data-test-id="ListItem.button.remove"]').exists()).toBeFalsy()
+    })
+
+    it(':editing - true, list of 2 does have remove ', (): void => {
+      const properties = ref({ editing: true, listLength: 2, index: 0 })
+      const wrapper: Wrapper<Vue> = mount(PprListItem, { propsData: properties.value, vuetify })
+
+      expect(wrapper.find('button[data-test-id="ListItem.button.remove"]').exists()).toBeTruthy()
+    })
+
+
+  })
+  describe('@events', (): void => {
+    it('@input - business name change should be emitted', async (): Promise<void> => {
+      const expected = 2
+      const properties = ref({ editing: true, listLength: 5, index: expected })
+      const wrapper: Wrapper<Vue> = mount(PprListItem, { propsData: properties.value, vuetify })
+
+      const button = wrapper.get('[data-test-id="ListItem.button.remove"]')
+      button.trigger('click')
+      await Vue.nextTick()
+
+      const emitted = wrapper.emitted('remove').slice(-1)[0][0]
+      expect(emitted).toBe(expected)
+    })
+
+  })
+})

--- a/ppr-ui/tests/unit/components/PprListItem.spec.ts
+++ b/ppr-ui/tests/unit/components/PprListItem.spec.ts
@@ -14,6 +14,21 @@ describe('PprListItem.vue', (): void => {
 
     // General form tests.
 
+    it(':editing - false, header does not exist', (): void => {
+      const properties = ref({ editing: false, listLength: 1, index: 0 })
+      const wrapper: Wrapper<Vue> = mount(PprListItem, { propsData: properties.value, vuetify })
+
+      expect(wrapper.find('div[data-test-id="ListItem.header.title"]').exists()).toBeFalsy()
+    })
+
+    it(':editing - false, list of 2 does not have remove ', (): void => {
+      const properties = ref({ editing: false, listLength: 2, index: 0 })
+      const wrapper: Wrapper<Vue> = mount(PprListItem, { propsData: properties.value, vuetify })
+
+      expect(wrapper.find('button[data-test-id="ListItem.button.remove"]').exists()).toBeFalsy()
+    })
+
+
     it(':editing - true, header exist', (): void => {
       const properties = ref({ editing: true, listLength: 1, index: 0 })
       const wrapper: Wrapper<Vue> = mount(PprListItem, { propsData: properties.value, vuetify })


### PR DESCRIPTION
Create a Vue component that can hold any content (e.g. secured party, debtor, serial collateral).
The component can expect these properties:
- editing (true when element is showing edit form)
- index (the index number of the contents)
- list length (the length of the list of items)

Component needs to provided a name slot to insert the appropriate prompt/header for the content.

Component needs to provide a X button (located top far right corner) when the list length is greater than or equal to 2. Emit a remove event with the content's index.

When not editing hide the prompt and the remove button.