### PR TITLE
Issue #781; Task for #647: Secured Parties component

### DIFF
--- a/ppr-ui/src/base-party/BaseParty.vue
+++ b/ppr-ui/src/base-party/BaseParty.vue
@@ -4,10 +4,6 @@
     class="base-party-form"
     @input="emitValidity(HEADER, $event)"
   >
-    <div v-if="editing">
-      <div> {{ value }} json: businessName {{ value.businessName.toJson() }} personName {{ value.personName.toJson() }} </div>
-      {{ prompt }}
-    </div>
     <v-container class="flex-center">
       <!-- See #724 re pending styling of these radio buttons -->
       <v-radio-group

--- a/ppr-ui/src/base-party/base-party-model.ts
+++ b/ppr-ui/src/base-party/base-party-model.ts
@@ -19,6 +19,11 @@ export class BasePartyModel {
   private _personName: PersonNameModel
 
   /**
+   * Provide a publicly accessible property that lists can use to index parties
+   */
+  public listId: number = 0
+
+  /**
    * Creates a new Base Party model instance.
    *
    * @param businessName the business name of the party.

--- a/ppr-ui/src/financing-statement/SecuredParties.vue
+++ b/ppr-ui/src/financing-statement/SecuredParties.vue
@@ -1,0 +1,124 @@
+<template>
+  <v-form>
+    <form-section-header label="Secured Parties" />
+    <v-container>
+      <v-list>
+        <ppr-list-item
+          v-for="(securedParty, index) in value"
+          :key="index"
+          :editing="editing"
+          :index="index"
+          :list-length="value.length"
+          @remove="removeElement"
+        >
+          <template #header>
+            Enter the contact information for this <strong>Secured Party</strong>
+          </template>
+          <base-party
+            :value="securedParty"
+            :editing="editing"
+            prompt="How should we identify this Secured Party?"
+            @input="updateElement($event, index)"
+            @valid="emitValidity($event, index)"
+          />
+        </ppr-list-item>
+      </v-list>
+    </v-container>
+    <v-container
+      v-if="editing"
+      class="flex-center"
+    >
+      <v-btn
+        data-test-id="SecuredParties.button.add"
+        @click="addElement"
+      >
+        <span>Add new secured party</span>
+      </v-btn>
+    </v-container>
+  </v-form>
+</template>
+
+<script lang="ts">
+import { createComponent, ref } from '@vue/composition-api'
+import { BasePartyModel } from '@/base-party/base-party-model'
+import BaseParty from '@/base-party/BaseParty.vue'
+import FormSectionHeader from '@/components/FormSectionHeader.vue'
+import PprListItem from '@/components/PprListItem.vue'
+
+export default createComponent({
+  components: {
+    BaseParty,
+    FormSectionHeader,
+    PprListItem
+  },
+  props: {
+    editing: {
+      default: false,
+      required: false,
+      type: Boolean
+    },
+    value: {
+      required: true,
+      type: Array // a list of parties
+    }
+  },
+
+  setup(props, { emit }) {
+
+    const formIsValid = ref<boolean>(false)
+
+    // Create a structure to hold the validation state of the elements of the list
+    // TODO consider if this needs to be reactive
+    const validationState: boolean[] = new Array(props.value.length).fill(false)
+
+    // Callback function for emitting form validity on the header section back to the parent.
+    function emitValidity(validElement: boolean, index: number) {
+      // save the validity of the element
+      validationState[index] = validElement
+      // Search the array for any false values. Note that 'find' returns undefined when all values are 'true'.
+      const notValid = validationState.includes(false)
+      formIsValid.value = !notValid
+      emit('valid', formIsValid.value)
+    }
+
+    // Vue is not able to detect changes inside arrays so when emitting the array of parties
+    // be sure to clone the array.
+    function updateElement(newSecuredParty: BasePartyModel, index: number): void {
+      let sp = [...props.value]
+      const previous: BasePartyModel = props.value[index] as BasePartyModel
+      newSecuredParty.listId = previous.listId
+      sp[index] = newSecuredParty
+      emit('input', sp)
+    }
+
+    function addElement() {
+      let sp = [...props.value]
+      const last: BasePartyModel = props.value[props.value.length - 1] as BasePartyModel
+      const newSecuredParty = new BasePartyModel()
+      newSecuredParty.listId = last.listId + 1
+      sp.push(newSecuredParty)
+      emit('input', sp)
+    }
+
+    function removeElement(index: number) {
+      let sp = [...props.value]
+      sp.splice(index, 1)
+      emit('input', sp)
+    }
+
+    return {
+      addElement,
+      emitValidity,
+      formIsValid,
+      removeElement,
+      updateElement
+    }
+  }
+})
+</script>
+
+<style lang="scss" scoped>
+.flex-center {
+  align-items: center;
+}
+</style>

--- a/ppr-ui/src/views/FinancingStatementView.vue
+++ b/ppr-ui/src/views/FinancingStatementView.vue
@@ -22,8 +22,9 @@
           </div>
           <v-form>
             <financing-statement
-              v-model="financingStatement"
+              :value="financingStatement"
               :editing="editing"
+              @input="updateFinancingModel"
               @valid="formValid = $event"
             />
             <v-btn
@@ -44,7 +45,7 @@
             </p>
           </div>
           <financing-statement
-            v-model="financingStatement"
+            :value="financingStatement"
             :editing="editing"
           />
         </section>
@@ -55,12 +56,13 @@
 
 <script lang="ts">
 import { createComponent, ref } from '@vue/composition-api'
-
 import FinancingStatement from '@/financing-statement/FinancingStatement.vue'
+import { BasePartyModel } from '@/base-party/base-party-model'
 import { FinancingStatementModel, FinancingStatementInterface } from '@/financing-statement/financing-statement-model'
 import { useLoadIndicator } from '@/load-indicator'
 import axiosAuth from '@/utils/axios-auth'
 import Config from '@/utils/config'
+
 
 export default createComponent({
   components: { FinancingStatement },
@@ -68,7 +70,13 @@ export default createComponent({
   setup(_, { root }) {
     const editing = ref(true)
     const formValid = ref(true)
-    const financingStatement = ref(new FinancingStatementModel())
+    // create FS model with defaults yet be sure secured parties has one empty party
+    const firstSecuredParty = new BasePartyModel()
+    firstSecuredParty.listId = 0
+    const securedParties = [firstSecuredParty]
+    const fstmt = new FinancingStatementModel(undefined, undefined, undefined, securedParties)
+    const financingStatement = ref(fstmt)
+
     const loadIndicator = useLoadIndicator()
     const regNum = root.$route.query ? root.$route.query['regNum'] as string : undefined
 
@@ -99,11 +107,16 @@ export default createComponent({
       editing.value = true
     }
 
+    function updateFinancingModel(newValue: FinancingStatementModel) {
+      financingStatement.value = newValue
+    }
+
     return {
       editing,
       financingStatement,
       formValid,
-      submit
+      submit,
+      updateFinancingModel
     }
   }
 })

--- a/ppr-ui/tests/unit/financing-statement/SecuredParties.spec.ts
+++ b/ppr-ui/tests/unit/financing-statement/SecuredParties.spec.ts
@@ -1,0 +1,77 @@
+import Vue from 'vue'
+import VueCompositionApi, { ref } from '@vue/composition-api'
+import { mount, Wrapper } from '@vue/test-utils'
+import { BasePartyModel } from '@/base-party/base-party-model'
+import { BusinessNameModel } from '@/components/business-model'
+import Vuetify from 'vuetify'
+
+import SecuredParties from '@/financing-statement/SecuredParties.vue'
+
+Vue.use(Vuetify)
+Vue.use(VueCompositionApi)
+const vuetify = new Vuetify()
+
+const firstSecuredParty = new BasePartyModel()
+firstSecuredParty.listId = 0
+const securedParties = [firstSecuredParty]
+
+describe('SecuredParties.vue', (): void => {
+  describe(':props', (): void => {
+
+    // General form tests.
+    it(':editing - false, add button does not exist', (): void => {
+      const properties = ref({ editing: false, value: securedParties })
+      const wrapper: Wrapper<Vue> = mount(SecuredParties, { propsData: properties.value, vuetify })
+
+      expect(wrapper.find('button[data-test-id="SecuredParties.button.add"]').exists()).toBeFalsy()
+    })
+    it(':editing - true, add button does exist', (): void => {
+      const properties = ref({ editing: true, value: securedParties })
+      const wrapper: Wrapper<Vue> = mount(SecuredParties, { propsData: properties.value, vuetify })
+
+      expect(wrapper.find('button[data-test-id="SecuredParties.button.add"]').exists()).toBeTruthy()
+    })
+
+  })
+  describe('@events', (): void => {
+    it('@input - add button should emit input with new list', async (): Promise<void> => {
+      const properties = ref({ editing: true, value: securedParties })
+      const wrapper: Wrapper<Vue> = mount(SecuredParties, { propsData: properties.value, vuetify })
+
+      const button = wrapper.get('[data-test-id="SecuredParties.button.add"]')
+      button.trigger('click')
+      await Vue.nextTick()
+
+      const emitted = wrapper.emitted('input').slice(-1)[0][0]
+      expect(emitted).toHaveLength(2)
+    })
+  })
+
+  describe('white box testing', (): void => {
+    it('remove method should emit input shorter list', async (): Promise<void> => {
+      const properties = ref({ editing: true, value: securedParties })
+      const wrapper: Wrapper<Vue> = mount(SecuredParties, { propsData: properties.value, vuetify })
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const vm: any = wrapper.vm
+      vm.removeElement()
+      await Vue.nextTick()
+
+      const emitted = wrapper.emitted('input').slice(-1)[0][0]
+      expect(emitted).toHaveLength(0)
+    })
+
+    it('update method should emit input with same list but updated element', async (): Promise<void> => {
+      const properties = ref({ editing: true, value: securedParties })
+      const wrapper: Wrapper<Vue> = mount(SecuredParties, { propsData: properties.value, vuetify })
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const vm: any = wrapper.vm
+      const updated = new BasePartyModel(new BusinessNameModel('aBusiness'))
+      vm.updateElement(updated, 0)
+      await Vue.nextTick()
+
+      const emitted = wrapper.emitted('input').slice(-1)[0][0]
+      expect(emitted).toHaveLength(1)
+      expect(emitted[0]).toEqual(updated)
+    })
+  })
+})


### PR DESCRIPTION
- use label rather than v-model
- add the model secured parties to the FS
To FS component:
- add the secured parties component
- use emitValid instead of the deprecated validForm
- store form validity for styling
- adjust update methods to account for secured parties
Remove unneeded code in BaseParty component
To base party model add a list identifier to be used by secured parties
Add SecuredParties component to display and manage a list of secured parties.



