### PR TITLE
Handle parties in database with no person name

### DIFF
--- a/ppr-api/src/models/party.py
+++ b/ppr-api/src/models/party.py
@@ -27,11 +27,12 @@ class Party(BaseORM):
     address = sqlalchemy.orm.relationship('Address')
 
     def as_schema(self):
+        person_name = schemas.party.IndividualName(
+            first=self.first_name, middle=self.middle_name, last=self.last_name
+        ) if self.last_name else None
         base_args = {
             'businessName': self.business_name,
-            'personName': schemas.party.IndividualName(
-                first=self.first_name, middle=self.middle_name, last=self.last_name
-            ),
+            'personName': person_name,
             'address': self.address.as_schema() if self.address else None
         }
 

--- a/ppr-api/tests/unit/models/test_party.py
+++ b/ppr-api/tests/unit/models/test_party.py
@@ -1,0 +1,21 @@
+import models.party
+
+
+def test_party_as_schema_business_name_is_used():
+    model = models.party.Party(business_name='Mr. Plow')
+
+    schema = model.as_schema()
+
+    assert schema.businessName == 'Mr. Plow'
+    assert schema.personName is None
+
+
+def test_party_as_schema_person_name_is_used():
+    model = models.party.Party(first_name='Homer', middle_name='Jay', last_name='Simpson')
+
+    schema = model.as_schema()
+
+    assert schema.personName.first == 'Homer'
+    assert schema.personName.middle == 'Jay'
+    assert schema.personName.last == 'Simpson'
+    assert schema.businessName is None


### PR DESCRIPTION
When a database record does not have a person name, ensure we don't try to build an empty `personName` instance when we send it back through the API