### PR TITLE
Issue 852 (task of 823) Don't show invalid form indicators on readonly

### DIFF
--- a/ppr-ui/src/base-party/BaseParty.vue
+++ b/ppr-ui/src/base-party/BaseParty.vue
@@ -1,7 +1,8 @@
 <template>
   <v-form
-    :class="{ invalid: !formIsValid }"
+    :class="getFormClass()"
     class="base-party-form"
+    data-test-id="BaseParty.form"
     @input="emitValidity(HEADER, $event)"
   >
     <v-container class="flex-center">
@@ -136,12 +137,19 @@ export default createComponent({
       emit('input', model)
     }
 
+    function getFormClass() {
+      return {
+        invalid: props.editing ? !formIsValid.value : false
+      }
+    }
+
     return {
       BUSINESS_NAME,
       HEADER,
       PERSON_NAME,
       changeType,
       formIsValid,
+      getFormClass,
       partyType,
       showBusinessName,
       showPersonName,

--- a/ppr-ui/src/financing-statement/FinancingStatement.vue
+++ b/ppr-ui/src/financing-statement/FinancingStatement.vue
@@ -1,7 +1,8 @@
 <template>
   <v-card outlined>
     <v-form
-      :class="{ formInvalid: !formIsValid }"
+      :class="getFormClass()"
+      data-test-id="FinancingStatement.form"
       @input="emitValid('header', $event)"
     >
       <form-section-header label="Type &amp; Duration" />
@@ -178,11 +179,18 @@ export default createComponent({
       ))
     }
 
+    function getFormClass() {
+      return {
+        formInvalid: props.editing ? !formIsValid.value : false
+      }
+    }
+
     return {
       fsTypes,
       formIsValid,
       life,
       lifeRules,
+      getFormClass,
       updateLife,
       updateDebtorParties,
       updateRegisteringParty,
@@ -196,6 +204,6 @@ export default createComponent({
 
 <style lang="scss" scoped>
 .formInvalid {
-  border: 1px solid blanchedalmond
+  border: 1px solid blanchedalmond;
 }
 </style>

--- a/ppr-ui/tests/unit/components/BaseParty.spec.ts
+++ b/ppr-ui/tests/unit/components/BaseParty.spec.ts
@@ -83,16 +83,18 @@ describe('BaseParty.vue', (): void => {
       // let element
       expect(wrapper.find('[data-test-id="BaseParty.radio.business"]').exists()).toBeFalsy()
       expect(wrapper.find('[data-test-id="BaseParty.radio.person"]').exists()).toBeFalsy()
+      expect(wrapper.find('[data-test-id="BaseParty.form"]').attributes().class).not.toContain('invalid')
 
       properties.value.editing = true
       await Vue.nextTick()
-      expect(wrapper.find('[data-test-id="BaseParty.radio.business"]').exists()).toBeTruthy()
       expect(wrapper.find('[data-test-id="BaseParty.radio.person"]').exists()).toBeTruthy()
+      expect(wrapper.find('[data-test-id="BaseParty.form"]').attributes().class).toContain('invalid')
 
       properties.value.editing = false
       await Vue.nextTick()
       expect(wrapper.find('[data-test-id="BaseParty.radio.business"]').exists()).toBeFalsy()
       expect(wrapper.find('[data-test-id="BaseParty.radio.person"]').exists()).toBeFalsy()
+      expect(wrapper.find('[data-test-id="BaseParty.form"]').attributes().class).not.toContain('invalid')
     })
 
   })
@@ -227,7 +229,7 @@ describe('BaseParty.vue', (): void => {
     })
 
     it('base party with person name should be visible and radio button set', async (): Promise<void> => {
-      const model = new BasePartyModel(undefined, new PersonNameModel('first',undefined,'last'))
+      const model = new BasePartyModel(undefined, new PersonNameModel('first', undefined, 'last'))
       const properties = ref({ editing: true, value: model })
       const wrapper: Wrapper<Vue> = mount(BaseParty, { propsData: properties.value, vuetify })
       const radioBusiness = wrapper.get('[data-test-id="BaseParty.radio.business"]').element as HTMLInputElement

--- a/ppr-ui/tests/unit/financing-statement/FinancingStatement.spec.ts
+++ b/ppr-ui/tests/unit/financing-statement/FinancingStatement.spec.ts
@@ -30,6 +30,18 @@ describe('FinancingStatmentContainer.vue', (): void => {
       expect(wrapper.findAll('input').exists()).toBeTruthy()
     })
 
+    it(':editing - true form defaults to invalid', async (): Promise<void> => {
+      const properties = ref({ editing: true, value: new FinancingStatementModel() })
+      const wrapper: Wrapper<Vue> = mount(FinancingStatement, { propsData: properties.value, vuetify })
+      expect(wrapper.find('[data-test-id="FinancingStatement.form"]').attributes().class).toContain('formInvalid')
+    })
+
+    it(':editing - false form defaults to valid', async (): Promise<void> => {
+      const properties = ref({ editing: false, value: new FinancingStatementModel() })
+      const wrapper: Wrapper<Vue> = mount(FinancingStatement, { propsData: properties.value, vuetify })
+      expect(wrapper.find('[data-test-id="FinancingStatement.form"]').attributes().class).not.toContain('formInvalid')
+    })
+
     it(':editing - false contains default type', (): void => {
       const properties = ref({ editing: false, value: new FinancingStatementModel() })
       const wrapper: Wrapper<Vue> = mount(FinancingStatement, { propsData: properties.value, vuetify })


### PR DESCRIPTION
When showing the successful registration the page had the red boxes.