### PR TITLE
Enhance use of registration "life" in the API

### DIFF
--- a/ppr-api/docs/api_contract/ppr-api.v1.yaml
+++ b/ppr-api/docs/api_contract/ppr-api.v1.yaml
@@ -315,7 +315,7 @@ paths:
                     baseRegistrationNumber: 791167G
                     documentId: B5645289
                     registrationDateTime: '2020-02-21T18:38:20Z'
-                    years: 5
+                    lifeYears: 5
         '422':
           description: Unprocessable Entity
       operationId: post-financing-statements
@@ -368,7 +368,7 @@ paths:
                       model: SLK-Class Kompressor
                   generalCollateral:
                     - description: A ride on lawn mower that has a great deal of personal value.
-                  years: 5
+                  lifeYears: 5
       parameters:
         - schema:
             type: string
@@ -560,16 +560,18 @@ components:
           type: string
           format: date-time
           description: The date when the registration was successfully created.
-        years:
+        lifeYears:
           type: integer
           minimum: 1
           maximum: 25
-          description: Length of the registration in years. Must be a value from 1 to 25.
+          description: Life of the registration in years. Must be a value from 1 to 25. Cannot be set when lifeInfinite is true. Cannot be set when type is REPAIRERS_LIEN. Required for other types when lifeInfinite is not true.
+        lifeInfinite:
+          type: boolean
+          description: Set to true if the registration has an infinite life (no expiry date). Cannot be true when lifeYears has a value. Cannot be true when type is REPAIRERS_LIEN. Must be true or lifeYears must have a value for remaining types.
       required:
         - type
         - securedParties
         - debtors
-        - years
     search-result:
       type: object
       description: Provides a link to the financing statement found after a successful search.

--- a/ppr-api/src/endpoints/financing_statement.py
+++ b/ppr-api/src/endpoints/financing_statement.py
@@ -52,7 +52,7 @@ def map_financing_statement_model_to_schema(model: models.financing_statement.Fi
 
     return schemas.financing_statement.FinancingStatement(
         baseRegistrationNumber=model.registration_number, registrationDateTime=reg_date,
-        expiryDate=model.expiry_date, years=model.life_in_years if model.life_in_years > 0 else None,
+        expiryDate=model.expiry_date, lifeYears=model.life_in_years if model.life_in_years > 0 else None,
         type=schemas.financing_statement.RegistrationType(model.registration_type_code).name,
         registeringParty=reg_party_schema, securedParties=secured_parties_schema, debtors=debtors_schema,
         vehicleCollateral=vehicle_collateral_schema, generalCollateral=general_collateral_schema

--- a/ppr-api/src/repository/financing_statement_repository.py
+++ b/ppr-api/src/repository/financing_statement_repository.py
@@ -43,7 +43,7 @@ class FinancingStatementRepository:
     def create_financing_statement(self, fs_input: schemas.financing_statement.FinancingStatementBase,
                                    user: auth.authentication.User):
         reg_num = self.next_registration_number()
-        years = fs_input.years or -1
+        years = fs_input.lifeYears or -1
         expiry_date = utils.datetime.today_pacific() + datedelta.datedelta(years=years) if years > 0 else None
 
         model = models.financing_statement.FinancingStatement(

--- a/ppr-api/src/schemas/financing_statement.py
+++ b/ppr-api/src/schemas/financing_statement.py
@@ -23,14 +23,15 @@ class RegistrationType(enum.Enum):
 
 class FinancingStatementBase(pydantic.BaseModel):  # pylint:disable=no-member
     type: str
-    years: int = None
+    lifeYears: int = None
+    lifeInfinite: bool = None
     registeringParty: schemas.party.Party = None
     securedParties: typing.List[schemas.party.Party]
     debtors: typing.List[schemas.party.Debtor]
     vehicleCollateral: typing.List[schemas.collateral.VehicleCollateral]
     generalCollateral: typing.List[schemas.collateral.GeneralCollateral]
 
-    @pydantic.validator('years', pre=True)
+    @pydantic.validator('lifeYears', pre=True)
     def validate_years(cls, years):  # pylint:disable=no-self-argument # noqa: N805
         if years is None:
             return None

--- a/ppr-api/tests/integration/api/test_financing_statement.py
+++ b/ppr-api/tests/integration/api/test_financing_statement.py
@@ -20,7 +20,7 @@ def test_read_financing_statement_with_root_object_details():
     assert body['baseRegistrationNumber'] == fin_stmt.registration_number
     assert body['type'] == 'SECURITY_AGREEMENT'
     assert body['expiryDate'] == fin_stmt.expiry_date.isoformat()
-    assert body['years'] == 5
+    assert body['lifeYears'] == 5
     assert body['registrationDateTime'] == fin_stmt.events[0].registration_date.isoformat(timespec='seconds')
 
 
@@ -32,7 +32,7 @@ def test_read_financing_statement_with_no_expiry():
     body = rv.json()
 
     assert body['expiryDate'] is None
-    assert body['years'] is None
+    assert body['lifeYears'] is None
 
 
 def test_read_financing_statement_with_changed_registering_party_should_provide_active_record():
@@ -141,14 +141,14 @@ def test_read_financing_statement_vehicle_collateral_details():
 
 def test_create_financing_statement_for_root_object_details():
     request_payload = get_minimal_payload()
-    request_payload.update(type='SECURITY_AGREEMENT', years=5)
+    request_payload.update(type='SECURITY_AGREEMENT', lifeYears=5)
 
     rv = client.post('/financing-statements', json=request_payload)
 
     assert rv.status_code == 201
     body = rv.json()
     assert body['type'] == 'SECURITY_AGREEMENT'
-    assert body['years'] == 5
+    assert body['lifeYears'] == 5
 
     registration_number = body['baseRegistrationNumber']
 

--- a/ppr-api/tests/unit/endpoints/test_financing_statement.py
+++ b/ppr-api/tests/unit/endpoints/test_financing_statement.py
@@ -42,7 +42,7 @@ def test_read_financing_statement_life_years_is_none_when_negative():
 
     result = endpoints.financing_statement.read_financing_statement(base_reg_num, repo)
 
-    assert result.years is None
+    assert result.lifeYears is None
     assert result.expiryDate == stub_fs.expiry_date  # expiry_date is None in this case
 
 
@@ -53,7 +53,7 @@ def test_read_financing_statement_life_years_is_applied_when_positive():
 
     result = endpoints.financing_statement.read_financing_statement(base_reg_num, repo)
 
-    assert result.years == 25
+    assert result.lifeYears == 25
     assert result.expiryDate == stub_fs.expiry_date
 
 

--- a/ppr-api/tests/unit/repository/test_financing_statement_repository.py
+++ b/ppr-api/tests/unit/repository/test_financing_statement_repository.py
@@ -37,7 +37,7 @@ def test_create_financing_statement_event_user_is_saved(mock_session):
 @patch('sqlalchemy.orm.Session')
 def test_create_financing_statement_should_not_expire_when_years_not_set(mock_session):
     repo = repository.financing_statement_repository.FinancingStatementRepository(mock_session)
-    schema = stub_financing_statement_input(years=None)
+    schema = stub_financing_statement_input(life_years=None)
 
     financing_statement = repo.create_financing_statement(schema, stub_user())
 
@@ -49,7 +49,7 @@ def test_create_financing_statement_should_not_expire_when_years_not_set(mock_se
 @patch('sqlalchemy.orm.Session')
 def test_create_financing_statement_leap_day_to_non_leap_year_should_expire_in_march(mock_session):
     repo = repository.financing_statement_repository.FinancingStatementRepository(mock_session)
-    schema = stub_financing_statement_input(years=3)
+    schema = stub_financing_statement_input(life_years=3)
 
     financing_statement = repo.create_financing_statement(schema, stub_user())
 
@@ -61,7 +61,7 @@ def test_create_financing_statement_leap_day_to_non_leap_year_should_expire_in_m
 @patch('sqlalchemy.orm.Session')
 def test_create_financing_statement_leap_day_to_leap_year_should_expire_on_leap_day(mock_session):
     repo = repository.financing_statement_repository.FinancingStatementRepository(mock_session)
-    schema = stub_financing_statement_input(years=24)
+    schema = stub_financing_statement_input(life_years=24)
 
     financing_statement = repo.create_financing_statement(schema, stub_user())
 
@@ -347,12 +347,13 @@ def stub_vehicle_collateral(vehicle_type: VehicleType = VehicleType.MANUFACTURED
     )
 
 
-def stub_financing_statement_input(reg_type: RegistrationType = RegistrationType.SECURITY_AGREEMENT, years: int = None,
-                                   reg_party: schemas.party.Party = stub_party(), secured_parties=[stub_party()],
-                                   debtors=[stub_debtor()], general_collateral=[], vehicle_collateral=[]):
+def stub_financing_statement_input(reg_type: RegistrationType = RegistrationType.SECURITY_AGREEMENT,
+                                   life_years: int = None, reg_party: schemas.party.Party = stub_party(),
+                                   secured_parties=[stub_party()], debtors=[stub_debtor()], general_collateral=[],
+                                   vehicle_collateral=[]):
     return schemas.financing_statement.FinancingStatementBase(
-        type=reg_type.name, years=years, registeringParty=reg_party, securedParties=secured_parties, debtors=debtors,
-        vehicleCollateral=vehicle_collateral, generalCollateral=general_collateral
+        type=reg_type.name, lifeYears=life_years, registeringParty=reg_party, securedParties=secured_parties,
+        debtors=debtors, vehicleCollateral=vehicle_collateral, generalCollateral=general_collateral
     )
 
 

--- a/ppr-api/tests/unit/schemas/test_financing_statement_schema.py
+++ b/ppr-api/tests/unit/schemas/test_financing_statement_schema.py
@@ -5,7 +5,7 @@ import schemas.financing_statement
 
 def test_financing_statement_years_not_integer():
     try:
-        schemas.financing_statement.FinancingStatementBase(years='25s', type='SA', securedParties=[], debtors=[],
+        schemas.financing_statement.FinancingStatementBase(lifeYears='25s', type='SA', securedParties=[], debtors=[],
                                                            vehicleCollateral=[], generalCollateral=[])
     except ValueError:
         pass
@@ -15,7 +15,7 @@ def test_financing_statement_years_not_integer():
 
 def test_financing_statement_years_integer_over_25():
     try:
-        schemas.financing_statement.FinancingStatementBase(years=26, type='SA', securedParties=[], debtors=[],
+        schemas.financing_statement.FinancingStatementBase(lifeYears=26, type='SA', securedParties=[], debtors=[],
                                                            vehicleCollateral=[], generalCollateral=[])
     except ValueError:
         pass
@@ -25,7 +25,7 @@ def test_financing_statement_years_integer_over_25():
 
 def test_financing_statement_years_integer_under_1():
     try:
-        schemas.financing_statement.FinancingStatementBase(years=-1, type='SA', securedParties=[], debtors=[],
+        schemas.financing_statement.FinancingStatementBase(lifeYears=-1, type='SA', securedParties=[], debtors=[],
                                                            vehicleCollateral=[], generalCollateral=[])
     except ValueError:
         pass
@@ -35,7 +35,7 @@ def test_financing_statement_years_integer_under_1():
 
 def test_financing_statement_years_integer_0():
     try:
-        schemas.financing_statement.FinancingStatementBase(years=0, type='SA', securedParties=[], debtors=[],
+        schemas.financing_statement.FinancingStatementBase(lifeYears=0, type='SA', securedParties=[], debtors=[],
                                                            vehicleCollateral=[], generalCollateral=[])
     except ValueError:
         pass
@@ -45,7 +45,7 @@ def test_financing_statement_years_integer_0():
 
 def test_financing_statement_years_fraction():
     try:
-        schemas.financing_statement.FinancingStatementBase(years=23.3, type='SA', securedParties=[], debtors=[],
+        schemas.financing_statement.FinancingStatementBase(lifeYears=23.3, type='SA', securedParties=[], debtors=[],
                                                            vehicleCollateral=[], generalCollateral=[])
     except ValueError:
         pass
@@ -54,21 +54,21 @@ def test_financing_statement_years_fraction():
 
 
 def test_financing_statement_years_no_value_provided():
-    financing_statement = schemas.financing_statement.FinancingStatementBase(years=None, type='SA', securedParties=[],
-                                                                             debtors=[], vehicleCollateral=[],
-                                                                             generalCollateral=[])
-    assert financing_statement.years is None
+    financing_statement = schemas.financing_statement.FinancingStatementBase(lifeYears=None, type='SA',
+                                                                             securedParties=[], debtors=[],
+                                                                             vehicleCollateral=[], generalCollateral=[])
+    assert financing_statement.lifeYears is None
 
 
 def test_financing_statement_years_25():
-    financing_statement = schemas.financing_statement.FinancingStatementBase(years=25, type='SA', securedParties=[],
+    financing_statement = schemas.financing_statement.FinancingStatementBase(lifeYears=25, type='SA', securedParties=[],
                                                                              debtors=[], vehicleCollateral=[],
                                                                              generalCollateral=[])
-    assert financing_statement.years == 25
+    assert financing_statement.lifeYears == 25
 
 
 def test_financing_statement_years_1():
-    financing_statement = schemas.financing_statement.FinancingStatementBase(years=1, type='SA', securedParties=[],
+    financing_statement = schemas.financing_statement.FinancingStatementBase(lifeYears=1, type='SA', securedParties=[],
                                                                              debtors=[], vehicleCollateral=[],
                                                                              generalCollateral=[])
-    assert financing_statement.years == 1
+    assert financing_statement.lifeYears == 1

--- a/ppr-ui/src/financing-statement/financing-statement-model.ts
+++ b/ppr-ui/src/financing-statement/financing-statement-model.ts
@@ -15,7 +15,7 @@ export interface FinancingStatementInterface {
   debtors: BasePartyInterface[];
   type: FinancingStatementType;
   vehicleCollateral: [];
-  years: number;
+  lifeYears: number;
 }
 
 export class FinancingStatementModel {
@@ -138,7 +138,7 @@ export class FinancingStatementModel {
       debtors: theDbers,
       type: this.type,
       vehicleCollateral: [],
-      years: this.years
+      lifeYears: this.years
     }
     return rval
   }
@@ -191,7 +191,7 @@ export class FinancingStatementModel {
 
     return new FinancingStatementModel(
       jsonObject.type,
-      jsonObject.years,
+      jsonObject.lifeYears,
       registeringParty,
       securedParties.length > 0 ? securedParties : undefined,
       debtorParties.length > 0 ? debtorParties : undefined,


### PR DESCRIPTION
Rename financing statement "years" to "lifeYears" in the API interface.  Update the spec to include infinite life with a "lifeInfinite" property.