### PR TITLE
Add Validation to Name Fields

### DIFF
--- a/ppr-api/src/schemas/party.py
+++ b/ppr-api/src/schemas/party.py
@@ -1,5 +1,6 @@
 import datetime
 import enum
+import re
 
 import pydantic
 
@@ -15,6 +16,11 @@ class IndividualName(pydantic.BaseModel):
     middle: str = None
     last: str
 
+    @pydantic.validator('*')
+    def validate_name_fields(cls, v):  # pylint:disable=no-self-argument # noqa: N805
+        assert re.match("^[a-zA-Z-']*$", v), '"IndividualName" contains invalid character'
+        return v
+
 
 class Address(pydantic.BaseModel):
     street: str
@@ -29,6 +35,13 @@ class Party(pydantic.BaseModel):
     personName: IndividualName = None
     businessName: str = None
     address: Address = None
+
+    @pydantic.validator('businessName')
+    def validate_alphanum_special(cls, v, values):  # pylint:disable=no-self-argument # noqa: N805
+        if values['personName'] is not None:
+            raise ValueError('Cannot have "personName" and "businessName"')
+        assert re.match('^[a-zA-Z-0-9-\'"&:,$%.+;/ ]*$', v), '"businessName" contains invalid character'
+        return v
 
 
 class Debtor(Party):

--- a/ppr-api/src/schemas/party.py
+++ b/ppr-api/src/schemas/party.py
@@ -41,7 +41,7 @@ class Party(pydantic.BaseModel):
         if values['personName'] is not None:
             raise ValueError('Cannot have "personName" and "businessName"')
         assert re.match('^[a-zA-Z-0-9\'"&:,$%.+;/ ]*$',
-                        v), '"businessName" can only contain the following special characters: & \' : , $ - ( ) % . + "  ; /'
+                        v), '"businessName" can only contain the following special characters: &\':,$-()%.+";/ '
         return v
 
 

--- a/ppr-api/src/schemas/party.py
+++ b/ppr-api/src/schemas/party.py
@@ -18,7 +18,7 @@ class IndividualName(pydantic.BaseModel):
 
     @pydantic.validator('*')
     def validate_name_fields(cls, v):  # pylint:disable=no-self-argument # noqa: N805
-        assert re.match("^[a-zA-Z-']*$", v), '"IndividualName" contains invalid character'
+        assert re.match("^[a-zA-Z- ']*$", v), '"IndividualName" contains invalid character'
         return v
 
 
@@ -40,7 +40,8 @@ class Party(pydantic.BaseModel):
     def validate_alphanum_special(cls, v, values):  # pylint:disable=no-self-argument # noqa: N805
         if values['personName'] is not None:
             raise ValueError('Cannot have "personName" and "businessName"')
-        assert re.match('^[a-zA-Z-0-9-\'"&:,$%.+;/ ]*$', v), '"businessName" contains invalid character'
+        assert re.match('^[a-zA-Z-0-9\'"&:,$%.+;/ ]*$',
+                        v), '"businessName" can only contain the following special characters: & \' : , $ - ( ) % . + "  ; /'
         return v
 
 

--- a/ppr-api/tests/integration/api/test_financing_statement.py
+++ b/ppr-api/tests/integration/api/test_financing_statement.py
@@ -54,7 +54,7 @@ def test_read_financing_statement_with_changed_registering_party_should_provide_
 def test_read_financing_statement_debtor_details():
     fin_stmt = sample_data_utility.create_test_financing_statement(
         debtors=[{
-            'first_name': 'Homer', 'middle_name': 'Jay', 'last_name': 'Simpson', 'business_name': 'Mr. Plow',
+            'first_name': 'Homer', 'middle_name': 'Jay', 'last_name': 'Simpson',
             'birthdate': datetime.date(1990, 6, 15),
             'address': {'line1': '742 Evergreen Terrace', 'line2': '1st floor', 'city': 'Springfield',
                         'region': 'BC', 'country': 'CA', 'postal_code': 'V1A 1A1'}
@@ -65,7 +65,6 @@ def test_read_financing_statement_debtor_details():
     body = rv.json()
 
     assert len(body['debtors']) == 1
-    assert body['debtors'][0]['businessName'] == 'Mr. Plow'
     assert body['debtors'][0]['personName']['first'] == 'Homer'
     assert body['debtors'][0]['personName']['middle'] == 'Jay'
     assert body['debtors'][0]['personName']['last'] == 'Simpson'
@@ -81,7 +80,7 @@ def test_read_financing_statement_debtor_details():
 def test_read_financing_statement_secured_party_details():
     fin_stmt = sample_data_utility.create_test_financing_statement(
         secured_parties=[{
-            'first_name': 'Homer', 'middle_name': 'Jay', 'last_name': 'Simpson', 'business_name': 'Mr. Plow',
+            'business_name': 'Mr. Plow',
             'address': {'line1': '742 Evergreen Terrace', 'line2': '1st floor', 'city': 'Springfield',
                         'region': 'BC', 'country': 'CA', 'postal_code': 'V1A 1A1'}
         }]
@@ -92,9 +91,6 @@ def test_read_financing_statement_secured_party_details():
 
     assert len(body['securedParties']) == 1
     assert body['securedParties'][0]['businessName'] == 'Mr. Plow'
-    assert body['securedParties'][0]['personName']['first'] == 'Homer'
-    assert body['securedParties'][0]['personName']['middle'] == 'Jay'
-    assert body['securedParties'][0]['personName']['last'] == 'Simpson'
     assert body['securedParties'][0]['address']['street'] == '742 Evergreen Terrace'
     assert body['securedParties'][0]['address']['streetAdditional'] == '1st floor'
     assert body['securedParties'][0]['address']['city'] == 'Springfield'
@@ -172,7 +168,6 @@ def test_create_financing_statement_persists_registering_party():
     request_payload.update(
         registeringParty={
             'businessName': 'Mr. Plow',
-            'personName': {'first': 'Homer', 'middle': 'Jay', 'last': 'Simpson'},
             'address': {'street': '742 Evergreen Terrace', 'streetAdditional': '1st floor', 'city': 'Springfield',
                         'region': 'BC', 'country': 'CA', 'postalCode': 'V1A 1A1'}
         }
@@ -182,7 +177,7 @@ def test_create_financing_statement_persists_registering_party():
 
     body = rv.json()
     assert 'registeringParty' in body
-    assert body['registeringParty']['personName']
+    assert body['registeringParty']['businessName']
     assert body['registeringParty']['address']
 
     registration_number = body['baseRegistrationNumber']
@@ -193,9 +188,6 @@ def test_create_financing_statement_persists_registering_party():
     assert registering_party.base_registration_number == registration_number
     assert registering_party.starting_registration_number == registration_number
     assert registering_party.ending_registration_number is None
-    assert registering_party.first_name == 'Homer'
-    assert registering_party.middle_name == 'Jay'
-    assert registering_party.last_name == 'Simpson'
     assert registering_party.business_name == 'Mr. Plow'
     assert registering_party.address.line1 == '742 Evergreen Terrace'
     assert registering_party.address.line2 == '1st floor'
@@ -209,7 +201,7 @@ def test_create_financing_statement_persists_secured_party():
     request_payload = get_minimal_payload()
     request_payload.update(
         securedParties=[{
-            'businessName': 'Mr. Plow', 'personName': {'first': 'Homer', 'middle': 'Jay', 'last': 'Simpson'},
+            'businessName': 'Mr. Plow',
             'address': {'street': '742 Evergreen Terrace', 'streetAdditional': '1st floor', 'city': 'Springfield',
                         'region': 'BC', 'country': 'CA', 'postalCode': 'V1A 1A1'}
         }]
@@ -228,9 +220,6 @@ def test_create_financing_statement_persists_secured_party():
     assert secured_parties[0].base_registration_number == registration_number
     assert secured_parties[0].starting_registration_number == registration_number
     assert secured_parties[0].ending_registration_number is None
-    assert secured_parties[0].first_name == 'Homer'
-    assert secured_parties[0].middle_name == 'Jay'
-    assert secured_parties[0].last_name == 'Simpson'
     assert secured_parties[0].business_name == 'Mr. Plow'
     assert secured_parties[0].address.line1 == '742 Evergreen Terrace'
     assert secured_parties[0].address.line2 == '1st floor'
@@ -245,7 +234,7 @@ def test_create_financing_statement_persists_debtor():
     request_payload = get_minimal_payload()
     request_payload.update(
         debtors=[{
-            'businessName': 'Mr. Plow', 'birthdate': '1990-06-15',
+            'birthdate': '1990-06-15',
             'personName': {'first': 'Homer', 'middle': 'Jay', 'last': 'Simpson'},
             'address': {'street': '742 Evergreen Terrace', 'streetAdditional': '1st floor', 'city': 'Springfield',
                         'region': 'BC', 'country': 'CA', 'postalCode': 'V1A 1A1'}
@@ -270,7 +259,6 @@ def test_create_financing_statement_persists_debtor():
     assert debtors[0].first_name == 'Homer'
     assert debtors[0].middle_name == 'Jay'
     assert debtors[0].last_name == 'Simpson'
-    assert debtors[0].business_name == 'Mr. Plow'
     assert debtors[0].birthdate == datetime.date(1990, 6, 15)
     assert debtors[0].address.line1 == '742 Evergreen Terrace'
     assert debtors[0].address.line2 == '1st floor'

--- a/ppr-api/tests/integration/api/test_search.py
+++ b/ppr-api/tests/integration/api/test_search.py
@@ -120,7 +120,6 @@ def test_read_singular_search_results():
 def test_search_results_should_provide_party_at_time_of_search():
     fin_stmt = sample_data_utility.create_test_financing_statement(
         registering_party={'first_name': 'Homer', 'middle_name': 'Jay', 'last_name': 'Simpson',
-                           'business_name': 'Mr. Plow',
                            'address':  {'line1': '724 Evergreen Terrace', 'line2': 'first floor', 'city': 'Springfield',
                                         'region': 'BC', 'country': 'CA', 'postal_code': 'V1A 1A1'}}
     )
@@ -138,7 +137,6 @@ def test_search_results_should_provide_party_at_time_of_search():
     assert reg_party['personName']['first'] == 'Homer'
     assert reg_party['personName']['middle'] == 'Jay'
     assert reg_party['personName']['last'] == 'Simpson'
-    assert reg_party['businessName'] == 'Mr. Plow'
     assert reg_party['address']['street'] == '724 Evergreen Terrace'
     assert reg_party['address']['streetAdditional'] == 'first floor'
     assert reg_party['address']['city'] == 'Springfield'
@@ -172,8 +170,7 @@ def test_search_results_should_provide_general_collateral_at_time_of_search():
 
 def test_search_results_should_provide_secured_parties_details():
     fin_stmt = sample_data_utility.create_test_financing_statement(
-        secured_parties=[{'first_name': 'Homer', 'middle_name': 'Jay', 'last_name': 'Simpson',
-                          'business_name': 'Mr. Plow',
+        secured_parties=[{'business_name': 'Mr. Plow',
                           'address':  {'line1': '724 Evergreen Terrace', 'line2': '1st floor', 'city': 'Springfield',
                                        'region': 'BC', 'country': 'CA', 'postal_code': 'V1A 1A1'}}]
     )
@@ -186,9 +183,6 @@ def test_search_results_should_provide_secured_parties_details():
 
     assert len(body[0]['financingStatement']['securedParties']) == 1
     secured_party = body[0]['financingStatement']['securedParties'][0]
-    assert secured_party['personName']['first'] == 'Homer'
-    assert secured_party['personName']['middle'] == 'Jay'
-    assert secured_party['personName']['last'] == 'Simpson'
     assert secured_party['businessName'] == 'Mr. Plow'
     assert secured_party['address']['street'] == '724 Evergreen Terrace'
     assert secured_party['address']['streetAdditional'] == '1st floor'
@@ -201,7 +195,7 @@ def test_search_results_should_provide_secured_parties_details():
 
 def test_search_results_should_provide_debtor_details():
     fin_stmt = sample_data_utility.create_test_financing_statement(
-        debtors=[{'first_name': 'Homer', 'middle_name': 'Jay', 'last_name': 'Simpson', 'business_name': 'Mr. Plow',
+        debtors=[{'first_name': 'Homer', 'middle_name': 'Jay', 'last_name': 'Simpson',
                   'birthdate': datetime.date(2019, 6, 17),
                   'address':  {'line1': '724 Evergreen Terrace', 'line2': '1st floor', 'city': 'Springfield',
                                'region': 'BC', 'country': 'CA', 'postal_code': 'V1A 1A1'}}]
@@ -218,7 +212,6 @@ def test_search_results_should_provide_debtor_details():
     assert debtor['personName']['first'] == 'Homer'
     assert debtor['personName']['middle'] == 'Jay'
     assert debtor['personName']['last'] == 'Simpson'
-    assert debtor['businessName'] == 'Mr. Plow'
     assert debtor['birthdate'] == datetime.date(2019, 6, 17).isoformat()
     assert debtor['address']['street'] == '724 Evergreen Terrace'
     assert debtor['address']['streetAdditional'] == '1st floor'

--- a/ppr-api/tests/unit/endpoints/test_financing_statement.py
+++ b/ppr-api/tests/unit/endpoints/test_financing_statement.py
@@ -120,7 +120,7 @@ def test_read_financing_statement_debtor_should_be_mapped_to_schema():
     debtor = models.party.Party(
         type_code=PartyType.DEBTOR.value, base_registration_number=base_reg_num,
         starting_registration_number=base_reg_num, first_name='Homer', middle_name='Jay', last_name='Simpson',
-        business_name='Mr. Plow', birthdate=datetime.date(1990, 6, 15)
+        birthdate=datetime.date(1990, 6, 15)
     )
     stub_fs = stub_financing_statement(base_reg_num, parties=[debtor])
     repo = MockFinancingStatementRepository(stub_fs)
@@ -133,7 +133,6 @@ def test_read_financing_statement_debtor_should_be_mapped_to_schema():
     assert debtor.personName.first == 'Homer'
     assert debtor.personName.middle == 'Jay'
     assert debtor.personName.last == 'Simpson'
-    assert debtor.businessName == 'Mr. Plow'
     assert debtor.birthdate == datetime.date(1990, 6, 15)
     assert debtor.address is None
 

--- a/ppr-api/tests/unit/endpoints/test_search.py
+++ b/ppr-api/tests/unit/endpoints/test_search.py
@@ -198,7 +198,7 @@ def test_read_search_results_provides_debtor_details():
     )
     event = stub_financing_statement_event(fin_stmt.registration_number)
     debtor = models.party.Party(
-        type_code='DE', first_name='Homer', middle_name='Jay', last_name='Simpson', business_name='Mr. Plow',
+        type_code='DE', first_name='Homer', middle_name='Jay', last_name='Simpson',
         birthdate=datetime.date(1990, 6, 15), base_registration_number=fin_stmt.registration_number,
         starting_registration_number=event.registration_number, address=models.party.Address(
             line1='742 Evergreen Terrace', line2='First Floor', city='Springfield', region='BC', country='CA',
@@ -216,7 +216,6 @@ def test_read_search_results_provides_debtor_details():
     assert results[0].financingStatement.debtors[0].personName.first == 'Homer'
     assert results[0].financingStatement.debtors[0].personName.middle == 'Jay'
     assert results[0].financingStatement.debtors[0].personName.last == 'Simpson'
-    assert results[0].financingStatement.debtors[0].businessName == 'Mr. Plow'
     assert results[0].financingStatement.debtors[0].birthdate == datetime.date(1990, 6, 15)
     assert results[0].financingStatement.debtors[0].address.street == '742 Evergreen Terrace'
     assert results[0].financingStatement.debtors[0].address.streetAdditional == 'First Floor'

--- a/ppr-api/tests/unit/schemas/test_party_schema.py
+++ b/ppr-api/tests/unit/schemas/test_party_schema.py
@@ -1,0 +1,204 @@
+import datetime
+
+import pytest
+
+import schemas.party
+
+
+def test_person_name_invalid_no_last():
+    try:
+        schemas.party.IndividualName(personName={'first': 'John Doe'})
+    except ValueError:
+        pass
+    else:
+        pytest.fail('A validation error was expected since last name is required')
+
+
+def test_person_name_invalid_no_first():
+    try:
+        schemas.party.IndividualName(personName={'last': 'John Doe'})
+    except ValueError:
+        pass
+    else:
+        pytest.fail('A validation error was expected since first name is required')
+
+
+def test_person_name_invalid_only_middle():
+    try:
+        schemas.party.IndividualName(personName={'middle': 'John Doe'})
+    except ValueError:
+        pass
+    else:
+        pytest.fail('A validation error was expected since first and last name are required')
+
+
+def test_person_name_invalid_first_and_middle():
+    try:
+        schemas.party.IndividualName(personName={'first': 'John', 'middle': 'Doe'})
+    except ValueError:
+        pass
+    else:
+        pytest.fail('A validation error was expected since last name is required')
+
+
+def test_person_name_invalid_last_and_middle():
+    try:
+        schemas.party.IndividualName(personName={'last': 'Doe', 'middle': 'John'})
+    except ValueError:
+        pass
+    else:
+        pytest.fail('A validation error was expected since first name is required')
+
+
+def test_person_name_invalid_not_alpha_first():
+    try:
+        schemas.party.IndividualName(first='J0hn', last='Doe')
+    except AssertionError:
+        pass
+    else:
+        pytest.fail('A validation error was expected since "first" contains invalid character')
+
+
+def test_person_name_invalid_not_alpha_last():
+    try:
+        schemas.party.IndividualName(first='John', last='Doe!')
+    except AssertionError:
+        pass
+    else:
+        pytest.fail('A validation error was expected since "last" contains invalid character')
+
+
+def test_person_name_invalid_not_alpha_middle():
+    try:
+        schemas.party.IndividualName(first='John', middle='$herman', last='Doe')
+    except AssertionError:
+        pass
+    else:
+        pytest.fail('A validation error was expected since "middle" contains invalid character')
+
+
+def test_person_name_valid_no_middle():
+    name = schemas.party.IndividualName(first='John', last='Doe')
+    assert name == {'first': 'John', 'middle': None, 'last': 'Doe'}
+
+
+def test_person_name_valid_with_middle():
+    name = schemas.party.IndividualName(first='John', middle='Sherman', last='Doe')
+    assert name == {'first': 'John', 'middle': 'Sherman', 'last': 'Doe'}
+
+
+def test_person_name_valid_with_special():
+    name = schemas.party.IndividualName(first="J'ohn-Boy", middle="D'ean-Dre", last="D'oe-Doughington")
+    assert name == {'first': "J'ohn-Boy", 'middle': "D'ean-Dre", 'last': "D'oe-Doughington"}
+
+
+def test_business_name_invalid_special_char():
+    try:
+        schemas.party.Party(businessName='Globotech!')
+    except AssertionError:
+        pass
+    else:
+        pytest.fail('A validation error was expected due to invalid character')
+
+
+def test_business_name_valid_simple():
+    name = schemas.party.Party(businessName='Globotech')
+    assert name.businessName == 'Globotech'
+
+
+def test_business_name_valid_special_chars_alphanumeric():
+    name = schemas.party.Party(businessName='Aa-\'"&:,$%.+;/zZ1234567890 ')
+    assert name.businessName == 'Aa-\'"&:,$%.+;/zZ1234567890 '
+
+
+def test_address_invalid_no_street():
+    try:
+        schemas.party.Address(city='Cranbrook', country='CA', postalCode='V8V 0B6')
+    except ValueError:
+        pass
+    else:
+        pytest.fail('A validation error was expected since "street" is required')
+
+
+def test_address_invalid_no_city():
+    try:
+        schemas.party.Address(street='123 Real Street', country='CA', postalCode='V8V 0B6')
+    except ValueError:
+        pass
+    else:
+        pytest.fail('A validation error was expected since "city" is required')
+
+
+def test_address_invalid_no_country():
+    try:
+        schemas.party.Address(street='123 Real Street', city='Cranbrook', postalCode='V8V 0B6')
+    except ValueError:
+        pass
+    else:
+        pytest.fail('A validation error was expected since "country" is required')
+
+
+def test_address_invalid_no_postal():
+    try:
+        schemas.party.Address(street='123 Real Street', city='Cranbrook', country='CA')
+    except ValueError:
+        pass
+    else:
+        pytest.fail('A validation error was expected since "postalCode" is required')
+
+
+def test_address_valid_no_optional():
+    address = schemas.party.Address(street='123 Real Street', city='Cranbrook',
+                                           country='CA', postalCode='V8V 0B6')
+
+    assert address == {'street': '123 Real Street', 'city': 'Cranbrook', 'country': 'CA',
+                       'postalCode': 'V8V 0B6', 'streetAdditional': None, 'region': None}
+
+
+def test_address_valid_optional():
+    address = schemas.party.Address(street='123 Real Street', city='Cranbrook', country='CA',
+                                    postalCode='V8V 0B6', streetAdditional='Suite 203', region='BC')
+
+    assert address == {'street': '123 Real Street', 'city': 'Cranbrook', 'country': 'CA',
+                       'postalCode': 'V8V 0B6', 'streetAdditional': 'Suite 203', 'region': 'BC'}
+
+
+def test_debtor_invalid_business_and_person_name():
+    try:
+        schemas.party.Debtor(address={'street': '123 Globo Street', 'city': 'Vancouver', 'country': 'CA',
+                                      'postalCode': 'V8V V8V', 'region': 'BC'},
+                             businessName='Globotech', personName={'first': 'John', 'last': 'Doe'})
+    except ValueError:
+        pass
+    else:
+        pytest.fail('A validation error was expected since Debtor cannot have both business and individual name')
+
+
+def test_debtor_valid_address_person_name():
+    debtor = schemas.party.Debtor(address={'street': '123 Real Street', 'city': 'Cranbrook', 'country': 'CA',
+                                           'postalCode': 'V8V 0B6', 'streetAdditional': 'Suite 203', 'region': 'BC'},
+                                  personName={'first': 'John', 'last': 'Doe'})
+    assert debtor.address == {'street': '123 Real Street', 'city': 'Cranbrook', 'country': 'CA',
+                              'postalCode': 'V8V 0B6', 'streetAdditional': 'Suite 203', 'region': 'BC'}
+    assert debtor.personName.first == 'John'
+    assert debtor.personName.last == 'Doe'
+
+
+def test_debtor_valid_address_business_name():
+    debtor = schemas.party.Debtor(address={'street': '123 Globo Street', 'city': 'Vancouver', 'country': 'CA',
+                                           'postalCode': 'V8V V8V', 'streetAdditional': 'Suite 900', 'region': 'BC'},
+                                  businessName='Globotech Industries')
+    assert debtor.address == {'street': '123 Globo Street', 'city': 'Vancouver', 'country': 'CA',
+                              'postalCode': 'V8V V8V', 'streetAdditional': 'Suite 900', 'region': 'BC'}
+    assert debtor.businessName == 'Globotech Industries'
+
+
+def test_debtor_valid_address_person_birthdate_included():
+    debtor = schemas.party.Debtor(address={'street': '123 Real Street', 'city': 'Cranbrook', 'country': 'CA',
+                                           'postalCode': 'V8V 0B6', 'streetAdditional': 'Suite 203', 'region': 'BC'},
+                                  birthdate=datetime.date(1965, 1, 1), personName={'first': 'Johnny', 'last': 'Dough'})
+    assert debtor.birthdate == datetime.date(1965, 1, 1)
+    assert debtor.address == {'street': '123 Real Street', 'city': 'Cranbrook', 'country': 'CA',
+                              'postalCode': 'V8V 0B6', 'streetAdditional': 'Suite 203', 'region': 'BC'}
+    assert debtor.personName.first == 'Johnny'
+    assert debtor.personName.last == 'Dough'

--- a/ppr-api/tests/unit/schemas/test_party_schema.py
+++ b/ppr-api/tests/unit/schemas/test_party_schema.py
@@ -7,7 +7,7 @@ import schemas.party
 
 def test_person_name_invalid_no_last():
     try:
-        schemas.party.IndividualName(personName={'first': 'John Doe'})
+        schemas.party.IndividualName(first='John Doe')
     except ValueError:
         pass
     else:
@@ -16,7 +16,7 @@ def test_person_name_invalid_no_last():
 
 def test_person_name_invalid_no_first():
     try:
-        schemas.party.IndividualName(personName={'last': 'John Doe'})
+        schemas.party.IndividualName(last='John Doe')
     except ValueError:
         pass
     else:
@@ -25,7 +25,7 @@ def test_person_name_invalid_no_first():
 
 def test_person_name_invalid_only_middle():
     try:
-        schemas.party.IndividualName(personName={'middle': 'John Doe'})
+        schemas.party.IndividualName(middle='John Doe')
     except ValueError:
         pass
     else:
@@ -34,7 +34,7 @@ def test_person_name_invalid_only_middle():
 
 def test_person_name_invalid_first_and_middle():
     try:
-        schemas.party.IndividualName(personName={'first': 'John', 'middle': 'Doe'})
+        schemas.party.IndividualName(first='John', middle='Doe')
     except ValueError:
         pass
     else:
@@ -43,7 +43,7 @@ def test_person_name_invalid_first_and_middle():
 
 def test_person_name_invalid_last_and_middle():
     try:
-        schemas.party.IndividualName(personName={'last': 'Doe', 'middle': 'John'})
+        schemas.party.IndividualName(last='Doe', middle='John')
     except ValueError:
         pass
     else:

--- a/ppr-api/tests/unit/schemas/test_party_schema.py
+++ b/ppr-api/tests/unit/schemas/test_party_schema.py
@@ -87,9 +87,19 @@ def test_person_name_valid_with_middle():
     assert name == {'first': 'John', 'middle': 'Sherman', 'last': 'Doe'}
 
 
-def test_person_name_valid_with_special():
-    name = schemas.party.IndividualName(first="J'ohn-Boy", middle="D'ean-Dre", last="D'oe-Doughington")
-    assert name == {'first': "J'ohn-Boy", 'middle': "D'ean-Dre", 'last': "D'oe-Doughington"}
+def test_person_first_name_valid_with_special():
+    name = schemas.party.IndividualName(first="J'ohn-Boy", last='Doe')
+    assert name == {'first': "J'ohn-Boy", 'middle': None, 'last': 'Doe'}
+
+
+def test_person_middle_name_valid_with_special():
+    name = schemas.party.IndividualName(first='John', middle="D'ean-Dre", last='Doe')
+    assert name == {'first': 'John', 'middle': "D'ean-Dre", 'last': 'Doe'}
+
+
+def test_person_last_name_valid_with_special():
+    name = schemas.party.IndividualName(first='John', last="D'oe-Doughington")
+    assert name == {'first': 'John', 'middle': None, 'last': "D'oe-Doughington"}
 
 
 def test_business_name_invalid_special_char():


### PR DESCRIPTION
First past at adding some validation to the Party Schema:

- personName is alphabetical other than hyphen ( - ) or apostrophe ( ' )

- businessName is alphanumeric plus allows the following special characters: & ' : , $ - ( ) % . + " " ; /

- Party cannot have businessName and personName

Also added basic tests for IndividualName and Address classes 