### PR TITLE
Upgrade to fastapi 0.52.0

### DIFF
--- a/ppr-api/Dockerfile
+++ b/ppr-api/Dockerfile
@@ -1,4 +1,5 @@
-FROM tiangolo/uvicorn-gunicorn-fastapi:python3.7-2019-10-15
+# Use fastapi 0.52.0 (https://github.com/tiangolo/uvicorn-gunicorn-fastapi-docker)
+FROM tiangolo/uvicorn-gunicorn-fastapi:uvicorn-gunicorn-fastapi:python3.7-2020-03-01
 
 COPY ./openshift/prestart.sh /app
 COPY ./alembic.ini /app

--- a/ppr-api/openshift/ppr-api-bc.yaml
+++ b/ppr-api/openshift/ppr-api-bc.yaml
@@ -18,7 +18,7 @@ objects:
     source:
       contextDir: ppr-api
       dockerfile: |
-        FROM tiangolo/uvicorn-gunicorn-fastapi:python3.7-2019-10-15
+        FROM tiangolo/uvicorn-gunicorn-fastapi:python3.7-2020-03-01
 
         COPY ./openshift/prestart.sh /app
         COPY ./alembic.ini /app

--- a/ppr-api/requirements/dev.txt
+++ b/ppr-api/requirements/dev.txt
@@ -2,7 +2,7 @@
 -r ../requirements.txt
 
 autopep8==1.5
-fastapi==0.42.0 # version tied to https://github.com/tiangolo/uvicorn-gunicorn-fastapi-docker
+fastapi==0.52.0 # version tied to https://github.com/tiangolo/uvicorn-gunicorn-fastapi-docker
 flake8==3.7.9
 flake8-blind-except==0.1.1
 flake8-debugger==3.2.1
@@ -10,6 +10,7 @@ flake8-isort==2.9.0
 flake8-quotes==2.1.1
 freezegun==0.3.15
 pep8-naming==0.9.1
+pydantic==1.4 # version tied to https://github.com/tiangolo/uvicorn-gunicorn-fastapi-docker
 pylint==2.4.3
 pytest==5.2.2
 pytest-cov==2.8.1

--- a/ppr-api/src/schemas/financing_statement.py
+++ b/ppr-api/src/schemas/financing_statement.py
@@ -32,6 +32,9 @@ class FinancingStatementBase(pydantic.BaseModel):
 
     @pydantic.validator('years', pre=True)
     def validate_years(cls, years):  # pylint:disable=no-self-argument # noqa: N805
+        if years is None:
+            return None
+
         if not type(years) is int:
             raise TypeError('Only integers are allowed')
         if years <= 0 or years > 25:


### PR DESCRIPTION
The 0.42.0 version of fastapi used pydantic 0.32.0 and we've been running against some validation limitations which made it difficult to work with.

Fastapi 0.52.0 uses pydantic 1.4 which has significant improvements.  In particular:
- We'll be able to use root object validators for more complex cases
- Returning `None` from a validator no longer causes errors, which allows for more complex cases
- We can't start using enum types as fields, which simplifies data conversion.