### PR TITLE
Correct life storage in the database

### DIFF
--- a/ppr-api/docs/sample_data/create_sample_financing_statements.sql
+++ b/ppr-api/docs/sample_data/create_sample_financing_statements.sql
@@ -1,10 +1,11 @@
 INSERT INTO financing_statement (reg_number, reg_type_cd, status, life, expiry_date) VALUES
-    ('123456A', 'SA', 'A', 5, now() + interval '5 years'),
+    ('123456A', 'SA', 'A', 7, now() + interval '7 years'),
     ('123456B', 'SA', 'A', -1, null);
 
 INSERT INTO registration (reg_number, base_reg_number, change_type_cd, reg_date, life, document_number) VALUES
-    ('123456A', '123456A', NULL, now(), null, 'A0000001'),
-    ('123456B', '123456B', NULL, now(), null, 'A0000002'),
+    ('123456A', '123456A', NULL, now(), 5, 'A0000001'),
+    ('123456C', '123456A', NULL, now() + interval '1 hour', 2, 'A0000004'),
+    ('123456B', '123456B', NULL, now(), -1, 'A0000002'),
     ('123456Z', '123456B', 'DT', now() + interval '1 hour', null, 'A0000003');
 
 INSERT INTO vehicle (base_reg_number, reg_number_start, reg_number_end, vehicle_type_cd, mhr_number, year, make, model, serial_number) VALUES

--- a/ppr-api/src/models/financing_statement.py
+++ b/ppr-api/src/models/financing_statement.py
@@ -84,6 +84,7 @@ class FinancingStatementEvent(BaseORM):
     description = sqlalchemy.Column(sqlalchemy.String)
     document_number = sqlalchemy.Column(sqlalchemy.String(length=8))
     user_id = sqlalchemy.Column(sqlalchemy.String(length=36))
+    life_in_years = sqlalchemy.Column('life', sqlalchemy.Integer)
 
     base_registration = sqlalchemy.orm.relationship('FinancingStatement', back_populates='events')
     starting_parties = sqlalchemy.orm.relationship(

--- a/ppr-api/src/repository/financing_statement_repository.py
+++ b/ppr-api/src/repository/financing_statement_repository.py
@@ -50,8 +50,9 @@ class FinancingStatementRepository:
             registration_number=reg_num, status='A', life_in_years=years, expiry_date=expiry_date,
             registration_type_code=schemas.financing_statement.RegistrationType[fs_input.type].value
         )
-        event_model = models.financing_statement.FinancingStatementEvent(registration_number=reg_num,
-                                                                         user_id=user.user_id)
+        event_model = models.financing_statement.FinancingStatementEvent(
+            registration_number=reg_num, user_id=user.user_id, life_in_years=years
+        )
 
         reg_party_model = map_party_schema_to_model(schemas.party.PartyType.REGISTERING, fs_input.registeringParty)
         secured_parties = list(map(lambda p: map_party_schema_to_model(schemas.party.PartyType.SECURED, p),


### PR DESCRIPTION
Correct life storage to have cumulative life stored on the financing statement and individual events (base registration and renewals) stored on events.