### PR TITLE
Rearrange the base party and submodels

### DIFF
--- a/ppr-ui/src/base-party/BaseParty.vue
+++ b/ppr-ui/src/base-party/BaseParty.vue
@@ -69,7 +69,8 @@ export default createComponent({
       type: String
     },
     value: {
-      required: true,
+      default: () => new BasePartyModel(),
+      required: false,
       type: BasePartyModel
     }
   },
@@ -92,7 +93,7 @@ export default createComponent({
     validationState[HEADER] = false
     validationState[PERSON_NAME] = false
 
-    let type = (props.value.personName.first || props.value.personName.last) ? PERSON_NAME : BUSINESS_NAME
+    let type = (props.value.personName?.first || props.value.personName?.last) ? PERSON_NAME : BUSINESS_NAME
     // partyType tracks the active name. Start showing one model, say, the business name
     const partyType = ref(type)
 

--- a/ppr-ui/src/base-party/base-party-model.ts
+++ b/ppr-ui/src/base-party/base-party-model.ts
@@ -5,16 +5,17 @@ import { PersonNameInterface, PersonNameModel } from '@/components/person-name-m
 /**
  * The interface to a party that may be a person or a business.
  */
-export interface BasePartyInterface extends PersonNameInterface, BusinessNameInterface {
+export interface BasePartyInterface {
+  businessName?: BusinessNameInterface['businessName'];
+  personName?: PersonNameInterface;
 }
 
 /**
  * The model for a that may be a person or a business, such as for a registering party.
  */
 export class BasePartyModel {
-
-  private _businessName: BusinessNameModel
-  private _personName: PersonNameModel
+  private _businessName?: BusinessNameModel
+  private _personName?: PersonNameModel
 
   /**
    * Provide a publicly accessible property that lists can use to index parties
@@ -27,10 +28,7 @@ export class BasePartyModel {
    * @param businessName the business name of the party.
    * @param personName the person name of the party.
    */
-  public constructor(
-    businessName: BusinessNameModel = new BusinessNameModel(),
-    personName: PersonNameModel = new PersonNameModel()
-  ) {
+  public constructor(businessName?: BusinessNameModel, personName?: PersonNameModel) {
     this._businessName = businessName
     this._personName = personName
   }
@@ -38,14 +36,14 @@ export class BasePartyModel {
   /**
    * Gets the business name of the party
    */
-  public get businessName(): BusinessNameModel {
+  public get businessName(): BusinessNameModel | undefined {
     return this._businessName
   }
 
   /**
    * Gets the person name of the party
    */
-  public get personName(): PersonNameModel {
+  public get personName(): PersonNameModel | undefined {
     return this._personName
   }
 
@@ -53,15 +51,16 @@ export class BasePartyModel {
    * Gets the JSON representation of the BasePartyModel object.
    */
   public toJson(): BasePartyInterface {
-    let rval = {}
-    if (this.businessName.businessName) {
-      let bm = this.businessName.toJson()
-      rval = Object.assign(rval, bm)
+    let rval: BasePartyInterface = {}
+
+    if (this.businessName?.businessName) {
+      rval = Object.assign(rval, this.businessName.toJson())
     }
-    if (this.personName.first || this.personName.last) {
-      let pm = this.personName.toJson()
-      rval = Object.assign(rval, pm)
+
+    if (this.personName?.first || this.personName?.last) {
+      rval = Object.assign(rval, { personName: this.personName.toJson() })
     }
+
     return rval
   }
 
@@ -74,19 +73,18 @@ export class BasePartyModel {
    *
    * @param jsonObject the JSON version of the object.
    */
-  public static fromJson(jsonObject: BasePartyInterface | undefined): BasePartyModel {
-    let businessName: BusinessNameModel | undefined
-    let personName: PersonNameModel | undefined
+  public static fromJson(jsonObject?: BasePartyInterface): BasePartyModel | undefined {
+    let basePartyModel: BasePartyModel | undefined
 
-    if (jsonObject && jsonObject.businessName) {
-      businessName = new BusinessNameModel(jsonObject.businessName)
+    if (jsonObject) {
+      let businessNameModel: BusinessNameModel | undefined
+      if (jsonObject.businessName) {
+        businessNameModel = BusinessNameModel.fromJson({ businessName: jsonObject.businessName })
+      }
+
+      basePartyModel = new BasePartyModel(businessNameModel, PersonNameModel.fromJson(jsonObject.personName))
     }
 
-    if (jsonObject && jsonObject.personName) {
-      const jp = jsonObject.personName
-      personName = new PersonNameModel(jp.first, jp.middle, jp.last)
-    }
-
-    return new BasePartyModel(businessName, personName)
+    return basePartyModel
   }
 }

--- a/ppr-ui/src/components/BusinessName.vue
+++ b/ppr-ui/src/components/BusinessName.vue
@@ -34,7 +34,8 @@ export default createComponent({
       type: Boolean
     },
     value: {
-      required: true,
+      default: () => new BusinessNameModel(),
+      required: false,
       type: BusinessNameModel
     }
   },

--- a/ppr-ui/src/components/PersonName.vue
+++ b/ppr-ui/src/components/PersonName.vue
@@ -46,7 +46,8 @@ export default createComponent({
       type: Boolean
     },
     value: {
-      required: true,
+      default: () => new PersonNameModel(),
+      required: false,
       type: PersonNameModel
     }
   },

--- a/ppr-ui/src/components/business-name-model.ts
+++ b/ppr-ui/src/components/business-name-model.ts
@@ -3,14 +3,14 @@
  * The interface to a business.
  */
 export interface BusinessNameInterface {
-  businessName?: string | undefined;
+  businessName?: string;
 }
 
 /**
  * The model for a business, such as a registering party, secured party, debtor
  */
 export class BusinessNameModel {
-  private _businessName: string | undefined
+  private _businessName?: string
 
   /**
    * Creates a new Business model instance.
@@ -33,9 +33,13 @@ export class BusinessNameModel {
    * Gets the JSON representation of the BusinessNameModel object.
    */
   public toJson(): BusinessNameInterface {
-    return {
-      businessName: this._businessName
+    let rval: BusinessNameInterface = {}
+
+    if (this.businessName) {
+      rval = Object.assign(rval, { businessName: this.businessName })
     }
+
+    return rval
   }
 
   /*
@@ -47,7 +51,13 @@ export class BusinessNameModel {
    *
    * @param jsonObject the JSON version of the object.
    */
-  public static fromJson(jsonObject: BusinessNameInterface): BusinessNameModel {
-    return new BusinessNameModel(jsonObject.businessName)
+  public static fromJson(jsonObject?: BusinessNameInterface): BusinessNameModel | undefined {
+    let businessNameModel: BusinessNameModel | undefined
+
+    if (jsonObject) {
+      businessNameModel = new BusinessNameModel(jsonObject.businessName)
+    }
+
+    return businessNameModel
   }
 }

--- a/ppr-ui/src/components/person-name-model.ts
+++ b/ppr-ui/src/components/person-name-model.ts
@@ -1,27 +1,19 @@
-
-interface PersonNameInnerInterface {
-  first: string | undefined;
-  middle: string | undefined;
-  last: string | undefined;
-}
 /**
  * The interface to a person name.
  */
 export interface PersonNameInterface {
-  personName?: PersonNameInnerInterface;
+  first?: string;
+  middle?: string;
+  last?: string;
 }
 
 /**
  * The model for a person name, such as for a registering party.
  */
-export class PersonNameModel implements PersonNameInterface {
-  // declare property to hold the person's name and match structure of the API.  Also need to explicitly construct
-  // the object so the constructor can refer to the inner properties (first, middle, last)
-  private _personName: PersonNameInnerInterface = {
-    first: undefined,
-    middle: undefined,
-    last: undefined
-  }
+export class PersonNameModel {
+  private _first?: string
+  private _middle?: string
+  private _last?: string
 
   /**
    * Creates a new Person Name model instance.
@@ -30,38 +22,31 @@ export class PersonNameModel implements PersonNameInterface {
    * @param middle the middle name of the person.
    * @param last the last name of the person.
    */
-  public constructor(first: string = '', middle: string = '', last: string = '') {
-    this._personName.first = first
-    this._personName.middle = middle
-    this._personName.last = last
-  }
-
-  /**
-   * Gets personName
-   */
-  public get personName(): PersonNameInnerInterface {
-    return this._personName
+  public constructor(first?: string, middle?: string, last?: string) {
+    this._first = first
+    this._middle = middle
+    this._last = last
   }
 
   /**
    * Gets the first name of the person.
    */
   public get first(): string | undefined {
-    return this._personName.first
+    return this._first
   }
 
   /**
    * Gets the middle name of the person.
    */
   public get middle(): string | undefined {
-    return this._personName.middle
+    return this._middle
   }
 
   /**
    * Gets the last name of the person.
    */
   public get last(): string | undefined {
-    return this._personName.last
+    return this._last
   }
 
   /**
@@ -69,11 +54,9 @@ export class PersonNameModel implements PersonNameInterface {
    */
   public toJson(): PersonNameInterface {
     return {
-      personName: {
-        first: this.first,
-        middle: this.middle,
-        last: this.last
-      }
+      first: this.first,
+      middle: this.middle,
+      last: this.last
     }
   }
 
@@ -86,10 +69,13 @@ export class PersonNameModel implements PersonNameInterface {
    *
    * @param jsonObject the JSON version of the object.
    */
-  public static fromJson(jsonObject: PersonNameInterface): PersonNameModel {
-    return new PersonNameModel(
-      jsonObject.personName.first,
-      jsonObject.personName.middle,
-      jsonObject.personName.last)
+  public static fromJson(jsonObject?: PersonNameInterface): PersonNameModel | undefined {
+    let personNameModel: PersonNameModel | undefined
+
+    if (jsonObject) {
+      personNameModel = new PersonNameModel(jsonObject.first, jsonObject.middle, jsonObject.last)
+    }
+
+    return personNameModel
   }
 }

--- a/ppr-ui/src/financing-statement/financing-statement-model.ts
+++ b/ppr-ui/src/financing-statement/financing-statement-model.ts
@@ -180,12 +180,19 @@ export class FinancingStatementModel {
 
     if (jsonObject.securedParties) {
       jsonObject.securedParties.forEach((sp: BasePartyInterface): void => {
-        securedParties.push(BasePartyModel.fromJson(sp))
+        const model = BasePartyModel.fromJson(sp)
+        if (model) {
+          securedParties.push(model)
+        }
       })
     }
+
     if (jsonObject.debtors) {
       jsonObject.debtors.forEach((sp: BasePartyInterface): void => {
-        debtorParties.push(BasePartyModel.fromJson(sp))
+        const model = BasePartyModel.fromJson(sp)
+        if (model) {
+          debtorParties.push(model)
+        }
       })
     }
 

--- a/ppr-ui/tests/unit/components/BaseParty.spec.ts
+++ b/ppr-ui/tests/unit/components/BaseParty.spec.ts
@@ -167,6 +167,7 @@ describe('BaseParty.vue', (): void => {
       await Vue.nextTick()
       wrapper.get('input[data-test-id="BusinessName.input.name"]').setValue('NewBusinessName')
       await Vue.nextTick()
+      await Vue.nextTick()
 
       expect(wrapper.emitted('valid').slice(-1)[0][0]).toBe(true)
     })
@@ -179,6 +180,7 @@ describe('BaseParty.vue', (): void => {
       await Vue.nextTick()
       wrapper.get('input[data-test-id="PersonName.first"]').setValue('afirst')
       wrapper.get('input[data-test-id="PersonName.last"]').setValue('alast')
+      await Vue.nextTick()
       await Vue.nextTick()
 
       expect(wrapper.emitted('valid').slice(-1)[0][0]).toBe(true)
@@ -197,6 +199,7 @@ describe('BaseParty.vue', (): void => {
       wrapper.get('input[data-test-id="PersonName.first"]').setValue('afirst')
       wrapper.get('input[data-test-id="PersonName.last"]').setValue('alast')
       await Vue.nextTick()
+      await Vue.nextTick()
       expect(wrapper.emitted('valid').slice(-1)[0][0]).toBe(true)
     })
 
@@ -211,6 +214,7 @@ describe('BaseParty.vue', (): void => {
       wrapper.find('[data-test-id="BaseParty.radio.business"]').trigger('click')
       await Vue.nextTick()
       wrapper.get('input[data-test-id="BusinessName.input.name"]').setValue('abusiness')
+      await Vue.nextTick()
       await Vue.nextTick()
       expect(wrapper.emitted('valid').slice(-1)[0][0]).toBe(true)
     })

--- a/ppr-ui/tests/unit/components/base-party-model.spec.ts
+++ b/ppr-ui/tests/unit/components/base-party-model.spec.ts
@@ -3,11 +3,11 @@ import { BusinessNameModel } from '@/components/business-name-model'
 import { PersonNameModel } from '@/components/person-name-model'
 
 describe('BasePartyModel', (): void => {
-  it('has empty business and person  with default constructor', (): void => {
+  it('has undefined business and person with default constructor', (): void => {
     const model = new BasePartyModel()
 
-    expect(model.businessName).toBeDefined()
-    expect(model.personName).toBeDefined()
+    expect(model.businessName).not.toBeDefined()
+    expect(model.personName).not.toBeDefined()
   })
 
   it('has business name when set', (): void => {
@@ -15,7 +15,7 @@ describe('BasePartyModel', (): void => {
     const businessName = new BusinessNameModel(name)
     const model = new BasePartyModel(businessName)
 
-    expect(model.businessName.businessName).toEqual(name)
+    expect(model.businessName?.businessName).toEqual(name)
   })
 
 
@@ -24,7 +24,37 @@ describe('BasePartyModel', (): void => {
     const person = new PersonNameModel(name, undefined, name)
     const model = new BasePartyModel(undefined, person)
 
-    expect(model.personName.first).toEqual(name)
+    expect(model.personName?.first).toEqual(name)
+  })
+
+  it('toJson produces no fields', (): void => {
+    const model = new BasePartyModel()
+
+    const json = model.toJson()
+
+    expect(json).toBeDefined()
+    expect(json.businessName).not.toBeDefined()
+    expect(json.personName).not.toBeDefined()
+    expect(BasePartyModel.fromJson(json)).toEqual(model)
+  })
+
+  it('toJson produces all fields', (): void => {
+    const businessName = 'Business Name'
+    const personFirstName = 'First Name'
+    const personMiddleName = 'Middle Name'
+    const personLastName = 'Last Name'
+    const business = new BusinessNameModel(businessName)
+    const person = new PersonNameModel(personFirstName, personMiddleName, personLastName)
+    const model = new BasePartyModel(business, person)
+
+    const json = model.toJson()
+
+    expect(json).toBeDefined()
+    expect(json.businessName).toBe(businessName)
+    expect(json.personName).toBeDefined()
+    expect(json.personName?.first).toBe(personFirstName)
+    expect(json.personName?.middle).toBe(personMiddleName)
+    expect(json.personName?.last).toBe(personLastName)
   })
 
   it('can construct using JSON', (): void => {
@@ -34,15 +64,14 @@ describe('BasePartyModel', (): void => {
     const person = new PersonNameModel(aPerson, undefined, aPerson)
     const model = new BasePartyModel(businessName, person)
 
-    const expected = BasePartyModel.fromJson(model.toJson())
-    expect(model).toEqual(expected)
+    const result = BasePartyModel.fromJson(model.toJson())
+    expect(model).toEqual(result)
   })
 
   it('can construct with undefined JSON', (): void => {
-    const model = new BasePartyModel()
+    const result = BasePartyModel.fromJson(undefined)
 
-    const expected = BasePartyModel.fromJson(undefined)
-    expect(model).toEqual(expected)
+    expect(result).not.toBeDefined()
   })
 
 })

--- a/ppr-ui/tests/unit/components/business-name-model.spec.ts
+++ b/ppr-ui/tests/unit/components/business-name-model.spec.ts
@@ -19,24 +19,50 @@ describe('business-name-model.ts', (): void => {
     expect(business.businessName).toEqual('aBusiness')
   })
 
-  it('works with JSON for default constructor', (): void => {
-    const business = new BusinessNameModel()
+  it('is undefined when fromJsoninput is undefined', (): void => {
+    const result = BusinessNameModel.fromJson()
 
-    const expected = BusinessNameModel.fromJson(business.toJson())
-    expect(business).toEqual(expected)
+    expect(result).not.toBeDefined()
   })
 
-  it('works with JSON', (): void => {
+  it('is an empty object when fromJson input is empty', (): void => {
+    const json = {}
+    const business = new BusinessNameModel()
+    const result = BusinessNameModel.fromJson(json)
+
+    expect(result).toEqual(business)
+    expect(business.toJson()).toEqual(json)
+  })
+
+  it('is a valid object when fromJson with data', (): void => {
     const business = new BusinessNameModel('aBusiness')
 
     const expected = BusinessNameModel.fromJson(business.toJson())
     expect(business).toEqual(expected)
   })
 
-  it('works with JSON having spaces and apostrophes', (): void => {
-    const business = new BusinessNameModel('O\'aBusiness')
+  it('is a valid object when fromJson with an apostrophe', (): void => {
+    const business = new BusinessNameModel("O'aBusiness")
 
     const expected = BusinessNameModel.fromJson(business.toJson())
     expect(business).toEqual(expected)
+  })
+
+  it('is expected json when toJson with no data', (): void => {
+    const business = new BusinessNameModel()
+
+    expect(business.toJson()).toEqual({})
+  })
+
+  it('is expected json when toJson with data', (): void => {
+    const business = new BusinessNameModel('aBusiness')
+
+    expect(business.toJson()).toEqual({ businessName: 'aBusiness' })
+  })
+
+  it('is expected json when toJson with an apostrophe', (): void => {
+    const business = new BusinessNameModel("O'aBusiness")
+
+    expect(business.toJson()).toEqual({ businessName: "O'aBusiness" })
   })
 })

--- a/ppr-ui/tests/unit/components/person-name-model.spec.ts
+++ b/ppr-ui/tests/unit/components/person-name-model.spec.ts
@@ -4,9 +4,9 @@ describe('person-name-model', (): void => {
   it('has empty names for default constructor', (): void => {
     const person = new PersonNameModel()
 
-    expect(person.first).toEqual('')
-    expect(person.middle).toEqual('')
-    expect(person.last).toEqual('')
+    expect(person.first).not.toBeDefined()
+    expect(person.middle).not.toBeDefined()
+    expect(person.last).not.toBeDefined()
   })
 
   it('has empty first name when set to be empty', (): void => {
@@ -45,24 +45,56 @@ describe('person-name-model', (): void => {
     expect(person.last).toEqual('Last')
   })
 
-  it('works with JSON for default constructor', (): void => {
-    const person = new PersonNameModel()
+  it('is undefined when fromJsoninput is undefined', (): void => {
+    const result = PersonNameModel.fromJson()
 
-    const expected = PersonNameModel.fromJson(person.toJson())
-    expect(person).toEqual(expected)
+    expect(result).not.toBeDefined()
   })
 
-  it('works with JSON', (): void => {
+  it('is an empty object when fromJson input is empty', (): void => {
+    const json = {}
+    const person = new PersonNameModel()
+    const result = PersonNameModel.fromJson(json)
+
+    expect(result).toEqual(person)
+    expect(person.toJson()).toEqual(json)
+  })
+
+  it('is a valid object when fromJson with data', (): void => {
     const person = new PersonNameModel('First', 'Middle', 'Last')
 
     const expected = PersonNameModel.fromJson(person.toJson())
     expect(person).toEqual(expected)
   })
 
-  it('works with JSON having spaces and apostrophes', (): void => {
-    const person = new PersonNameModel('O\'First', 'O\'Middle', 'von O\'Last')
+  it('is a valid object when fromJson with an apostrophe', (): void => {
+    const person = new PersonNameModel("O'First", "O'Middle", "von O'Last")
 
     const expected = PersonNameModel.fromJson(person.toJson())
     expect(person).toEqual(expected)
+  })
+
+  it('is expected json when toJson with no data', (): void => {
+    const json = {}
+    const person = new PersonNameModel()
+
+    expect(person.toJson()).toEqual(json)
+    expect(PersonNameModel.fromJson(json)).toEqual(person)
+  })
+
+  it('is expected json when toJson with data', (): void => {
+    const json = { first: 'First', middle: 'Middle', last: 'Last' }
+    const person = new PersonNameModel('First', 'Middle', 'Last')
+
+    expect(person.toJson()).toEqual(json)
+    expect(PersonNameModel.fromJson(json)).toEqual(person)
+  })
+
+  it('is expected json when toJson with an apostrophe', (): void => {
+    const json = { first: "O'First", middle: "O'Middle", last: "von O'Last" }
+    const person = new PersonNameModel("O'First", "O'Middle", "von O'Last")
+
+    expect(person.toJson()).toEqual(json)
+    expect(PersonNameModel.fromJson(json)).toEqual(person)
   })
 })

--- a/ppr-ui/tests/unit/financing-statement/FinancingStatement.spec.ts
+++ b/ppr-ui/tests/unit/financing-statement/FinancingStatement.spec.ts
@@ -130,7 +130,7 @@ describe('FinancingStatmentContainer.vue', (): void => {
       return financingStatement
     }
     // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-    function addParty(list) {
+    function addParty(list: BasePartyModel[]) {
       let sp = [...list]
       const last: BasePartyModel = list[list.length - 1] as BasePartyModel
       const newParty = new BasePartyModel()

--- a/ppr-ui/tests/unit/financing-statement/financing-statement.spec.ts
+++ b/ppr-ui/tests/unit/financing-statement/financing-statement.spec.ts
@@ -94,7 +94,7 @@ describe('FinancingStatementModel', (): void => {
 
       expect(fstmt.securedParties).toBeDefined()
       expect(fstmt.securedParties.length).toBe(1)
-      expect(fstmt.securedParties[0].personName.first).toEqual(testPerson.first)
+      expect(fstmt.securedParties[0].personName?.first).toEqual(testPerson.first)
     })
 
 


### PR DESCRIPTION
Updated the BaseParty model and the models it uses, so that fromJson handles undefined. This allows the logic to stay within the model, so that anything using the model is simpler. 

Changed the person name model to be a single layer, rather than the double set of interfaces.

Made toJson and fromJson stricter WRT handling empty objects and undefined fields.