### PR TITLE
Store account id on transactions

### DIFF
--- a/ppr-api/docs/sample_data/create_sample_financing_statements.sql
+++ b/ppr-api/docs/sample_data/create_sample_financing_statements.sql
@@ -16,11 +16,11 @@ INSERT INTO vehicle (base_reg_number, reg_number_start, reg_number_end, vehicle_
     ('123456B', '123456B', '123456Z', 'MV', null, 2002, 'Toyota', 'Avalon', '4T1BF28B82U291010'),
     ('123456B', '123456Z', null, 'MV', null, 1998, 'Pontiac', 'Grand Prix', '1G2WP1211WF243800');
 
-INSERT INTO general (base_reg_number, reg_number_start, reg_number_end, description) VALUES
-    ('123456A', '123456A', null, 'An original description of general collateral'),
-    ('123456B', '123456B', null, 'Everything in my kitchen except the sink'),
-    ('123456B', '123456B', '123456Z', ', plus an additional line that was originally appended, but should now be ignored except on historical views.'),
-    ('123456B', '123456Z', null, 'My sink should now be included');
+INSERT INTO general (base_reg_number, reg_number_start, reg_number_end, description, gc_ind) VALUES
+    ('123456A', '123456A', null, 'An original description of general collateral', 1),
+    ('123456B', '123456B', null, 'Everything in my kitchen except the sink', 1),
+    ('123456B', '123456B', '123456Z', ', plus an additional line that was originally appended, but should now be ignored except on historical views.', 2),
+    ('123456B', '123456Z', null, 'My sink should now be included', 1);
 
 INSERT INTO address(addr_id, addr_line_1, addr_line_2, city, province, country_type_cd, postal_cd) VALUES
     (10000001, '123 Fake Street', 'Suite 100', 'Victoria', 'BC', 'CA', 'V1V 1V1'),

--- a/ppr-api/migrations/versions/0cd6352f62d1_add_account_id_columns.py
+++ b/ppr-api/migrations/versions/0cd6352f62d1_add_account_id_columns.py
@@ -1,0 +1,28 @@
+"""Add account id columns
+
+Revision ID: 0cd6352f62d1
+Revises: a40891a0a749
+Create Date: 2020-04-02 12:10:13.644635
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '0cd6352f62d1'
+down_revision = 'a40891a0a749'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('financing_statement', sa.Column('account_id', sa.String(length=36)))
+    op.add_column('registration', sa.Column('account_id', sa.String(length=36)))
+    op.add_column('search', sa.Column('account_id', sa.String(length=36)))
+
+
+def downgrade():
+    op.drop_column('search', 'account_id')
+    op.drop_column('registration', 'account_id')
+    op.drop_column('financing_statement', 'account_id')

--- a/ppr-api/migrations/versions/a40891a0a749_add_sequence_to_general_collateral.py
+++ b/ppr-api/migrations/versions/a40891a0a749_add_sequence_to_general_collateral.py
@@ -1,0 +1,24 @@
+"""Add sequence to general collateral
+
+Revision ID: a40891a0a749
+Revises: 29a8ce790e7d
+Create Date: 2020-04-02 09:58:10.019236
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = 'a40891a0a749'
+down_revision = '29a8ce790e7d'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('general', sa.Column('gc_ind', sa.Integer))
+
+
+def downgrade():
+    op.drop_column('general', 'gc_ind')

--- a/ppr-api/src/auth/authentication.py
+++ b/ppr-api/src/auth/authentication.py
@@ -42,10 +42,11 @@ def get_user_from_auth(auth: fastapi.security.http.HTTPAuthorizationCredentials 
     return auth_response.json()
 
 
-def get_current_user(auth_api_user: dict = fastapi.Depends(get_user_from_auth)):
-    return User(user_id=auth_api_user['keycloakGuid'], user_name=auth_api_user['username'])
+def get_current_user(auth_api_user: dict = fastapi.Depends(get_user_from_auth), account_id: str = fastapi.Header(None)):
+    return User(user_id=auth_api_user['keycloakGuid'], user_name=auth_api_user['username'], account_id=account_id)
 
 
 class User(BaseModel):
     user_id: str
     user_name: str
+    account_id: str = None

--- a/ppr-api/src/models/collateral.py
+++ b/ppr-api/src/models/collateral.py
@@ -22,6 +22,7 @@ class GeneralCollateral(BaseORM):
     ending_registration_number = sqlalchemy.Column('reg_number_end', sqlalchemy.String(length=10),
                                                    sqlalchemy.ForeignKey(REGISTRATION_KEY))
     description = sqlalchemy.Column(sqlalchemy.String)
+    index = sqlalchemy.Column('gc_ind', sqlalchemy.Integer)
 
     @staticmethod
     def list_as_schema(general_collateral: list, events: list):
@@ -36,10 +37,11 @@ class GeneralCollateral(BaseORM):
         Returns:
             list of schemas.collateral.GeneralCollateral
         """
-        # For each starting event, the general collateral descriptions should be joined together into one
         def grouped_gc_to_schema(event_reg_number, gc_event_list):
+            """For each starting event, the general collateral descriptions should be joined together into one"""
             event = next((e for e in events if e.registration_number == event_reg_number), None)
-            description = ''.join(map(lambda gc: gc.description, gc_event_list))
+            sorted_collateral = sorted(gc_event_list, key=lambda e: e.index or 0)
+            description = ''.join(map(lambda gc: gc.description, sorted_collateral))
             return schemas.collateral.GeneralCollateral(
                 description=description, addedDateTime=event.registration_date if event else None
             )

--- a/ppr-api/src/models/financing_statement.py
+++ b/ppr-api/src/models/financing_statement.py
@@ -19,6 +19,7 @@ class FinancingStatement(BaseORM):
     life_in_years = sqlalchemy.Column('life', sqlalchemy.Integer)
     expiry_date = sqlalchemy.Column(sqlalchemy.Date)
     discharged = sqlalchemy.Column(sqlalchemy.BOOLEAN)
+    account_id = sqlalchemy.Column(sqlalchemy.String(length=36))  # Designates ownership of the financing statement
     last_updated = sqlalchemy.Column('last_update_timestamp', sqlalchemy.DateTime, server_default=sqlalchemy.func.now(),
                                      onupdate=sqlalchemy.func.now())
 
@@ -83,6 +84,7 @@ class FinancingStatementEvent(BaseORM):
     registration_date = sqlalchemy.Column('reg_date', sqlalchemy.DateTime, server_default=sqlalchemy.func.now())
     description = sqlalchemy.Column(sqlalchemy.String)
     document_number = sqlalchemy.Column(sqlalchemy.String(length=8))
+    account_id = sqlalchemy.Column(sqlalchemy.String(length=36))
     user_id = sqlalchemy.Column(sqlalchemy.String(length=36))
     life_in_years = sqlalchemy.Column('life', sqlalchemy.Integer)
 

--- a/ppr-api/src/models/search.py
+++ b/ppr-api/src/models/search.py
@@ -15,6 +15,7 @@ class Search(BaseORM):
     criteria = sqlalchemy.Column(postgresql.JSONB)
     creation_date_time = sqlalchemy.Column(sqlalchemy.DateTime, server_default=sqlalchemy.func.now())
     type_code = sqlalchemy.Column('type_long_code', sqlalchemy.String(length=40))
+    account_id = sqlalchemy.Column(sqlalchemy.String(length=36))
     user_id = sqlalchemy.Column(sqlalchemy.String(length=36))
     payment_id = sqlalchemy.Column(sqlalchemy.BigInteger, sqlalchemy.ForeignKey('payment.id'))
 

--- a/ppr-api/src/repository/financing_statement_repository.py
+++ b/ppr-api/src/repository/financing_statement_repository.py
@@ -48,10 +48,11 @@ class FinancingStatementRepository:
 
         model = models.financing_statement.FinancingStatement(
             registration_number=reg_num, status='A', life_in_years=years, expiry_date=expiry_date,
-            registration_type_code=schemas.financing_statement.RegistrationType[fs_input.type].value
+            registration_type_code=schemas.financing_statement.RegistrationType[fs_input.type].value,
+            account_id=user.account_id
         )
         event_model = models.financing_statement.FinancingStatementEvent(
-            registration_number=reg_num, user_id=user.user_id, life_in_years=years
+            registration_number=reg_num, user_id=user.user_id, account_id=user.account_id, life_in_years=years
         )
 
         reg_party_model = map_party_schema_to_model(schemas.party.PartyType.REGISTERING, fs_input.registeringParty)

--- a/ppr-api/src/repository/financing_statement_repository.py
+++ b/ppr-api/src/repository/financing_statement_repository.py
@@ -59,10 +59,11 @@ class FinancingStatementRepository:
                                    fs_input.securedParties))
         debtors = list(map(lambda p: map_party_schema_to_model(schemas.party.PartyType.DEBTOR, p, p.birthdate),
                            fs_input.debtors))
-
-        general_collateral = list(map(lambda c: models.collateral.GeneralCollateral(description=c.description),
-                                      fs_input.generalCollateral))
         vehicle_collateral = list(map(map_vehicle_collateral_schema_to_model, fs_input.vehicleCollateral))
+        general_collateral = list(
+            map(lambda e: models.collateral.GeneralCollateral(description=e[1].description, index=e[0]),
+                enumerate(fs_input.generalCollateral, start=1))
+        )
 
         model.events.append(event_model)
         model.parties.append(reg_party_model)

--- a/ppr-api/src/repository/search_repository.py
+++ b/ppr-api/src/repository/search_repository.py
@@ -4,6 +4,7 @@ import fastapi
 import sqlalchemy.orm
 
 import auth.authentication
+import models.database
 import models.payment
 import models.search
 import schemas.payment
@@ -19,7 +20,8 @@ class SearchRepository:
     def create_search(self, search_input: schemas.search.SearchBase, exact_matches: typing.List[str],
                       similar_matches: typing.List[str], user: auth.authentication.User,
                       payment: schemas.payment.Payment):
-        model = models.search.Search(criteria=search_input.criteria, type_code=search_input.type, user_id=user.user_id)
+        model = models.search.Search(criteria=search_input.criteria, type_code=search_input.type, user_id=user.user_id,
+                                     account_id=user.account_id)
         model.payment = models.payment.Payment(id=payment.id, method=payment.method, status=payment.status)
 
         for match in exact_matches:

--- a/ppr-api/tests/integration/api/test_financing_statement.py
+++ b/ppr-api/tests/integration/api/test_financing_statement.py
@@ -143,7 +143,7 @@ def test_create_financing_statement_for_root_object_details():
     request_payload = get_minimal_payload()
     request_payload.update(type='SECURITY_AGREEMENT', lifeYears=5)
 
-    rv = client.post('/financing-statements', json=request_payload)
+    rv = client.post('/financing-statements', json=request_payload, headers={'Account-Id': 'fake_account_id'})
 
     assert rv.status_code == 201
     body = rv.json()
@@ -160,11 +160,13 @@ def test_create_financing_statement_for_root_object_details():
     assert stored.life_in_years == 5
     assert stored.expiry_date.isoformat() == body['expiryDate']
     assert stored.last_updated
+    assert stored.account_id == 'fake_account_id'
 
     assert len(stored.events) == 1
     assert stored.events[0].registration_number == registration_number
     assert stored.events[0].base_registration_number == registration_number
     assert stored.events[0].user_id == 'fake_user_id'  # Default user for integration tests
+    assert stored.events[0].account_id == 'fake_account_id'
     assert stored.events[0].registration_date.isoformat(timespec='seconds') == body['registrationDateTime']
 
 

--- a/ppr-api/tests/integration/api/test_search.py
+++ b/ppr-api/tests/integration/api/test_search.py
@@ -27,7 +27,7 @@ def test_read_search(mock_payment):
 def test_create_registration_number_search():
     search_input = {'type': 'REGISTRATION_NUMBER', 'criteria': {'value': '987654Z'}}
 
-    rv = client.post('/searches', json=search_input)
+    rv = client.post('/searches', json=search_input, headers={'Account-Id': 'fake_account_id'})
 
     assert rv.status_code == 201
     body = rv.json()
@@ -41,6 +41,7 @@ def test_create_registration_number_search():
     assert stored.type_code == 'REGISTRATION_NUMBER'
     assert stored.criteria == {'value': '987654Z'}
     assert stored.user_id == 'fake_user_id'  # Default user for integration tests
+    assert stored.account_id == 'fake_account_id'
     assert body['searchDateTime'] == stored.creation_date_time.isoformat(timespec='seconds')
 
 

--- a/ppr-api/tests/integration/conftest.py
+++ b/ppr-api/tests/integration/conftest.py
@@ -14,12 +14,12 @@ db.close()
 
 
 @pytest.fixture(autouse=True)
-def default_current_user_dependency():
-    """Override the get_current_user Fast API dependency to eliminate the need for an external Auth API service"""
-    def mock_get_current_user():
-        return auth.authentication.User(user_id='fake_user_id', user_name='fake_user_name')
+def default_remote_user_dependency():
+    """Override the get_user_from_auth Fast API dependency to eliminate the need for an external Auth API service"""
+    def mock_get_user_from_auth():
+        return {'keycloakGuid': 'fake_user_id', 'username': 'fake_user_name'}
 
-    main.app.dependency_overrides[auth.authentication.get_current_user] = mock_get_current_user
+    main.app.dependency_overrides[auth.authentication.get_user_from_auth] = mock_get_user_from_auth
 
 
 def create_mock_remote_payment():

--- a/ppr-api/tests/integration/utilities/sample_data_utility.py
+++ b/ppr-api/tests/integration/utilities/sample_data_utility.py
@@ -49,8 +49,8 @@ def create_test_financing_statement(**kwargs):
         for debtor_input in options['debtors']:
             add_test_party(fin_stmt, event, 'DE', **debtor_input)
 
-        for description in options['general_collateral']:
-            collateral = models.collateral.GeneralCollateral(description=description)
+        for description_enum in enumerate(options['general_collateral'], start=1):
+            collateral = models.collateral.GeneralCollateral(description=description_enum[1], index=description_enum[0])
             fin_stmt.general_collateral.append(collateral)
             event.starting_general_collateral.append(collateral)
 
@@ -119,8 +119,8 @@ def create_test_financing_statement_event(fin_stmt: models.financing_statement.F
         if options['general_collateral'] is not None:
             for existing_collateral in fin_stmt.general_collateral:
                 event.ending_general_collateral.append(existing_collateral)
-            for description in options['general_collateral']:
-                collateral = models.collateral.GeneralCollateral(description=description)
+            for desc_enum in enumerate(options['general_collateral'], start=1):
+                collateral = models.collateral.GeneralCollateral(description=desc_enum[1], index=desc_enum[0])
                 fin_stmt.general_collateral.append(collateral)
                 event.starting_general_collateral.append(collateral)
 

--- a/ppr-api/tests/unit/auth/test_authentication.py
+++ b/ppr-api/tests/unit/auth/test_authentication.py
@@ -71,11 +71,13 @@ def test_get_user_from_auth_with_unexpected_response(mock_get):
 def test_get_current_user():
     auth_api_user = {'keycloakGuid': 'dad87b8e-0c80-4c8d-815b-0967cc68d65d',
                      'username': 'bcsc/32b44e37aa6a40019de1068c4891da10'}
+    account_id = '1234567'
 
-    user = auth.authentication.get_current_user(auth_api_user)
+    user = auth.authentication.get_current_user(auth_api_user, account_id)
 
     assert user.user_id == 'dad87b8e-0c80-4c8d-815b-0967cc68d65d'
     assert user.user_name == 'bcsc/32b44e37aa6a40019de1068c4891da10'
+    assert user.account_id == account_id
 
 
 def test_check_auth_response_forbidden_has_no_description_field():

--- a/ppr-api/tests/unit/endpoints/test_financing_statement.py
+++ b/ppr-api/tests/unit/endpoints/test_financing_statement.py
@@ -162,8 +162,8 @@ def test_read_financing_statement_debtor_address_should_be_mapped_to_schema():
 
 def test_read_financing_statement_general_collateral_should_be_included():
     base_reg_num = '123456D'
-    collateral1 = models.collateral.GeneralCollateral(description='collateral description')
-    collateral2 = models.collateral.GeneralCollateral(description=' plus appended portion')
+    collateral1 = models.collateral.GeneralCollateral(description='collateral description', index=1)
+    collateral2 = models.collateral.GeneralCollateral(description=' plus appended portion', index=2)
     stub_fs = stub_financing_statement(base_reg_num, general_collateral=[collateral1, collateral2])
     collateral1.start_event = stub_fs.get_base_event()
     collateral2.start_event = stub_fs.get_base_event()

--- a/ppr-api/tests/unit/models/test_collateral.py
+++ b/ppr-api/tests/unit/models/test_collateral.py
@@ -8,8 +8,9 @@ import schemas.collateral
 def test_general_collateral_list_as_schema_should_group_items_with_same_start():
     event = models.financing_statement.FinancingStatementEvent(registration_number='1234',
                                                                registration_date=datetime.datetime.now())
-    model1 = models.collateral.GeneralCollateral(description='Test description', starting_registration_number='1234')
-    model2 = models.collateral.GeneralCollateral(description=' - Part 2', starting_registration_number='1234')
+    model1 = models.collateral.GeneralCollateral(description='Test description', index=1,
+                                                 starting_registration_number='1234')
+    model2 = models.collateral.GeneralCollateral(description=' - Part 2', index=2, starting_registration_number='1234')
 
     schema = models.collateral.GeneralCollateral.list_as_schema([model1, model2], [event])
 
@@ -24,8 +25,10 @@ def test_general_collateral_list_as_schema_should_not_group_items_with_different
     event1 = models.financing_statement.FinancingStatementEvent(registration_number='1234', registration_date=now)
     event2 = models.financing_statement.FinancingStatementEvent(registration_number='4321',
                                                                 registration_date=now + datetime.timedelta(seconds=1))
-    model1 = models.collateral.GeneralCollateral(description='Test description 1', starting_registration_number='1234')
-    model2 = models.collateral.GeneralCollateral(description='Test description 2', starting_registration_number='4321')
+    model1 = models.collateral.GeneralCollateral(description='Test description 1', index=1,
+                                                 starting_registration_number='1234')
+    model2 = models.collateral.GeneralCollateral(description='Test description 2', index=2,
+                                                 starting_registration_number='4321')
 
     schema = models.collateral.GeneralCollateral.list_as_schema([model1, model2], [event1, event2])
 
@@ -37,13 +40,41 @@ def test_general_collateral_list_as_schema_should_not_group_items_with_different
 
 
 def test_general_collateral_list_as_schema_should_use_none_date_when_event_not_found():
-    model = models.collateral.GeneralCollateral(description='Test description', starting_registration_number='1234')
+    model = models.collateral.GeneralCollateral(description='Test description', index=1,
+                                                starting_registration_number='1234')
 
     schema = models.collateral.GeneralCollateral.list_as_schema([model], [])
 
     assert len(schema) == 1
     assert schema[0].addedDateTime is None
     assert schema[0].description == 'Test description'
+
+
+def test_general_collateral_list_as_schema_should_sort_by_index_before_joining():
+    event = models.financing_statement.FinancingStatementEvent(registration_number='1234',
+                                                               registration_date=datetime.datetime.now())
+    model1 = models.collateral.GeneralCollateral(description='1', index=1, starting_registration_number='1234')
+    model2 = models.collateral.GeneralCollateral(description='2', index=2, starting_registration_number='1234')
+    model3 = models.collateral.GeneralCollateral(description='3', index=3, starting_registration_number='1234')
+    model4 = models.collateral.GeneralCollateral(description='4', index=4, starting_registration_number='1234')
+
+    # Send the collateral into the method in scrambled order to verify they get sorted
+    schema = models.collateral.GeneralCollateral.list_as_schema([model3, model1, model4, model2], [event])
+
+    assert schema[0].description == '1234'
+
+
+def test_general_collateral_list_as_schema_with_empty_index_should_use_existing_order():
+    event = models.financing_statement.FinancingStatementEvent(registration_number='1234',
+                                                               registration_date=datetime.datetime.now())
+    model1 = models.collateral.GeneralCollateral(description='1', starting_registration_number='1234')
+    model2 = models.collateral.GeneralCollateral(description='2', starting_registration_number='1234')
+    model3 = models.collateral.GeneralCollateral(description='3', starting_registration_number='1234')
+    model4 = models.collateral.GeneralCollateral(description='4', starting_registration_number='1234')
+
+    schema = models.collateral.GeneralCollateral.list_as_schema([model1, model2, model3, model4], [event])
+
+    assert schema[0].description == '1234'
 
 
 def test_vehicle_collateral_as_schema_with_motor_vehicle():

--- a/ppr-api/tests/unit/repository/test_financing_statement_repository.py
+++ b/ppr-api/tests/unit/repository/test_financing_statement_repository.py
@@ -360,4 +360,4 @@ def stub_financing_statement_input(
 
 
 def stub_user(user_id: str = '12345'):
-    return auth.authentication.User(user_id=user_id, user_name='fred')
+    return auth.authentication.User(user_id=user_id, user_name='fred', account_id='54321')

--- a/ppr-api/tests/unit/repository/test_search_repository.py
+++ b/ppr-api/tests/unit/repository/test_search_repository.py
@@ -11,7 +11,7 @@ import schemas.search
 def test_create_search_fills_column_fields(mock_session):
     repo = repository.search_repository.SearchRepository(mock_session)
     search_input = schemas.search.SearchBase(type=schemas.search.SearchType.MHR_NUMBER.value, criteria={'value': '123'})
-    user = auth.authentication.User(user_id='12345', user_name='fred')
+    user = auth.authentication.User(user_id='12345', user_name='fred', account_id='54321')
     payment = schemas.payment.Payment(id=1234, status='COMPLETED', method='CC')
 
     search = repo.create_search(search_input, [], [], user, payment)
@@ -19,6 +19,7 @@ def test_create_search_fills_column_fields(mock_session):
     assert search.criteria == {'value': '123'}
     assert search.type_code == schemas.search.SearchType.MHR_NUMBER.value
     assert search.user_id == '12345'
+    assert search.account_id == '54321'
 
 
 @patch('sqlalchemy.orm.Session')


### PR DESCRIPTION
Store the Account-Id on data created from write transactions

Because they both have alembic scripts, this PR includes the same commit as #886 in order to maintain proper sequencing.

You can review https://github.com/bcgov/ppr/commit/3432e8c803100c73f64382389170c278b6ba5726 if you only want to see the changes excluding #886.