### PR TITLE
Correct registration type specific behaviour in API

### DIFF
--- a/ppr-api/docs/api_contract/ppr-api.v1.yaml
+++ b/ppr-api/docs/api_contract/ppr-api.v1.yaml
@@ -268,6 +268,7 @@ paths:
                         documentId: D0000123
                         registrationDateTime: '2020-01-02T21:08:32Z'
                         lifeYears: 5
+                        trustIndenture: false
                         payment:
                           id: 1234
                           status: CREATED
@@ -391,7 +392,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/financing-statement'
               examples:
-                New Financing Statement:
+                New Security Agreement:
                   value:
                     type: SECURITY_AGREEMENT
                     registeringParty:
@@ -437,6 +438,7 @@ paths:
                     documentId: B5645289
                     registrationDateTime: '2020-02-21T18:38:20Z'
                     lifeYears: 5
+                    trustIndenture: false
                     payment:
                       id: 1234
                       status: CREATED
@@ -453,7 +455,7 @@ paths:
             schema:
               $ref: '#/components/schemas/financing-statement'
             examples:
-              Register Financing Statement:
+              Register a Security Agreement:
                 value:
                   type: SECURITY_AGREEMENT
                   registeringParty:
@@ -495,6 +497,7 @@ paths:
                     - description: A ride on lawn mower that has a great deal of personal value.
                       addedDateTime: '2020-02-21T18:38:20Z'
                   lifeYears: 5
+                  trustIndenture: false
       parameters:
         - schema:
             type: string
@@ -888,6 +891,7 @@ paths:
                       detailsAdded:
                         type: SECURITY_AGREEMENT
                         lifeYears: 2
+                        trustIndenture: false
                         expiryDate: '2022-02-21'
                         registeringParty:
                           businessName: Mr. Plow
@@ -1127,6 +1131,7 @@ paths:
                       registrationDateTime: '2020-02-21T18:38:20Z'
                       detailsAdded:
                         type: SECURITY_AGREEMENT
+                        trustIndenture: false
                         lifeYears: 2
                         expiryDate: '2022-02-21'
                         registeringParty:
@@ -1411,6 +1416,17 @@ components:
           description: Set to true if the registration has an infinite life (no expiry date). Cannot be true when lifeYears has a value. Cannot be true when type is REPAIRERS_LIEN. Must be true or lifeYears must have a value for remaining types.
         payment:
           $ref: '#/components/schemas/payment'
+        trustIndenture:
+          type: boolean
+          description: Indicates if security interest is contained in a Trust Indenture. Required when the type is SECURITY_AGREEMENT. Should be null otherwise.
+        lienAmount:
+          type: string
+          maxLength: 15
+          description: The value of a lien. Required when the type is REPAIRERS_LIEN. Should be null otherwise.
+        surrenderDate:
+          type: string
+          format: date
+          description: The date the vehicle was or will be  surrendered to the owner. When provided it must be within the past 21 days or a later date. Required when the type is REPAIRERS_LIEN. Should be null otherwise.
       required:
         - type
         - securedParties

--- a/ppr-api/docs/sample_data/create_sample_financing_statements.sql
+++ b/ppr-api/docs/sample_data/create_sample_financing_statements.sql
@@ -1,12 +1,14 @@
-INSERT INTO financing_statement (reg_number, reg_type_cd, status, life, expiry_date) VALUES
-    ('123456A', 'SA', 'A', 7, now() + interval '7 years'),
-    ('123456B', 'SA', 'A', -1, null);
+INSERT INTO financing_statement (reg_number, reg_type_cd, status, life, expiry_date, trust, lien_value, surrender_date) VALUES
+    ('123456A', 'SA', 'A', 7, now() + interval '7 years', false, null, null),
+    ('123456B', 'SA', 'A', -1, null, true, null, null),
+    ('234567R', 'RL', 'A', null, now() + interval '180 days', null, '1000', now() - interval '10 days');
 
 INSERT INTO registration (reg_number, base_reg_number, change_type_cd, reg_date, life, document_number) VALUES
     ('123456A', '123456A', NULL, now(), 5, 'A0000001'),
     ('123456C', '123456A', NULL, now() + interval '1 hour', 2, 'A0000004'),
     ('123456B', '123456B', NULL, now(), -1, 'A0000002'),
-    ('123456Z', '123456B', 'DT', now() + interval '1 hour', null, 'A0000003');
+    ('123456Z', '123456B', 'DT', now() + interval '1 hour', null, 'A0000003'),
+    ('234567R', '234567R', NULL, now(), null, 'A0000005');
 
 INSERT INTO vehicle (base_reg_number, reg_number_start, reg_number_end, vehicle_type_cd, mhr_number, year, make, model, serial_number) VALUES
     ('123456A', '123456A', null, 'MH', '123456', null, null, null, '67517679I8677863567654321'),
@@ -14,7 +16,8 @@ INSERT INTO vehicle (base_reg_number, reg_number_start, reg_number_end, vehicle_
     ('123456A', '123456A', null, 'MV', null, 2103, 'Volkswagen', 'Tiguan', 'WVGBV7AX3DW537085'),
     ('123456B', '123456B', null, 'MV', null, 2003, 'Jeep', 'Wrangler', '1J4FA59S53P387692'),
     ('123456B', '123456B', '123456Z', 'MV', null, 2002, 'Toyota', 'Avalon', '4T1BF28B82U291010'),
-    ('123456B', '123456Z', null, 'MV', null, 1998, 'Pontiac', 'Grand Prix', '1G2WP1211WF243800');
+    ('123456B', '123456Z', null, 'MV', null, 1998, 'Pontiac', 'Grand Prix', '1G2WP1211WF243800'),
+    ('234567R', '234567R', null, 'MV', null, 2006, 'Jeep', 'Liberty', '1J4GL48K06W265262');
 
 INSERT INTO general (base_reg_number, reg_number_start, reg_number_end, description, gc_ind) VALUES
     ('123456A', '123456A', null, 'An original description of general collateral', 1),
@@ -28,7 +31,10 @@ INSERT INTO address(addr_id, addr_line_1, addr_line_2, city, province, country_t
     (10000003, '742 Evergreen Terrace', null, 'Springfield', 'CA', 'US', '54321'),
     (10000004, '55 Cobblestone Rd', null, 'Bedrock', null, 'GB', 'A1 1AA'),
     (10000005, '345 Cave Stone Road', 'Apt 405', 'Hollyrock', 'BC', 'CA', 'V2V 2V2'),
-    (10000006, '1000 Mammon Lane', null, 'Springfield', 'BC', 'CA', 'V3V 3V3');
+    (10000006, '1000 Mammon Lane', null, 'Springfield', 'BC', 'CA', 'V3V 3V3'),
+    (10000007, '321 Fake St', null, 'Victoria', 'BC', 'CA', 'V3V 3V3'),
+    (10000008, '742 Evergreen Terrace', null, 'Springfield', 'CA', 'US', '54321'),
+    (10000009, '1000 Mammon Lane', null, 'Springfield', 'BC', 'CA', 'V3V 3V3');
 
 INSERT INTO fs_party (party_type_cd, base_reg_num, reg_number_start, reg_number_end, addr_id, first_name, middle_name, last_name, business_name, birthdate) VALUES
     ('RP', '123456A', '123456A', null, 10000002, 'Homer', 'Jay', 'Simpson', 'Mr. Plow', null),
@@ -36,4 +42,7 @@ INSERT INTO fs_party (party_type_cd, base_reg_num, reg_number_start, reg_number_
     ('DE', '123456B', '123456B', '123456Z', 10000001, 'George', null, 'Jetson', null, '2000-01-01'),
     ('SP', '123456B', '123456B', null, 10000006, 'Charles', 'Montgomery', 'Burns', null, null),
     ('RP', '123456B', '123456Z', null, 10000004, 'Flintstone', null, 'Fred', null, null),
-    ('DE', '123456B', '123456Z', null, 10000005, 'Rubble', null, 'Barney', null, '1900-02-28');
+    ('DE', '123456B', '123456Z', null, 10000005, 'Rubble', null, 'Barney', null, '1900-02-28'),
+    ('RP', '234567R', '234567R', null, 10000008, 'Homer', 'Jay', 'Simpson', 'Mr. Plow', null),
+    ('SP', '234567R', '234567R', null, 10000009, 'Charles', 'Montgomery', 'Burns', null, null),
+    ('DE', '234567R', '234567R', null, 10000007, 'George', null, 'Jetson', null, '2000-01-01');

--- a/ppr-api/migrations/versions/78102181c4b3_remove_null_constraint_from_financing_.py
+++ b/ppr-api/migrations/versions/78102181c4b3_remove_null_constraint_from_financing_.py
@@ -1,0 +1,23 @@
+"""Remove null constraint from financing_statement.life
+
+Revision ID: 78102181c4b3
+Revises: 0cd6352f62d1
+Create Date: 2020-04-02 17:50:20.516154
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '78102181c4b3'
+down_revision = '0cd6352f62d1'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column('financing_statement', 'life', nullable=True)
+
+
+def downgrade():
+    op.alter_column('financing_statement', 'life', nullable=False)

--- a/ppr-api/src/models/financing_statement.py
+++ b/ppr-api/src/models/financing_statement.py
@@ -22,6 +22,9 @@ class FinancingStatement(BaseORM):
     account_id = sqlalchemy.Column(sqlalchemy.String(length=36))  # Designates ownership of the financing statement
     last_updated = sqlalchemy.Column('last_update_timestamp', sqlalchemy.DateTime, server_default=sqlalchemy.func.now(),
                                      onupdate=sqlalchemy.func.now())
+    trust_indenture = sqlalchemy.Column('trust', sqlalchemy.BOOLEAN)
+    surrender_date = sqlalchemy.Column(sqlalchemy.Date)
+    lien_amount = sqlalchemy.Column('lien_value', sqlalchemy.String(length=15))
 
     events = sqlalchemy.orm.relationship('FinancingStatementEvent', back_populates='base_registration')
     parties = sqlalchemy.orm.relationship(
@@ -44,7 +47,7 @@ class FinancingStatement(BaseORM):
         base_event = self.get_base_event()
         reg_date = base_event.registration_date if base_event else None
         reg_party_model = self.get_registering_party()
-        infinite = self.life_in_years == -1
+        infinite = self.life_in_years == -1 if self.life_in_years is not None else None
         years = self.life_in_years if not infinite else None
 
         reg_party_schema = reg_party_model.as_schema() if reg_party_model else None
@@ -57,6 +60,7 @@ class FinancingStatement(BaseORM):
         return schemas.financing_statement.FinancingStatement(
             baseRegistrationNumber=self.registration_number, registrationDateTime=reg_date, expiryDate=self.expiry_date,
             lifeYears=years, lifeInfinite=infinite, type=RegistrationType(self.registration_type_code).name,
+            trustIndenture=self.trust_indenture, lienAmount=self.lien_amount, surrenderDate=self.surrender_date,
             registeringParty=reg_party_schema, securedParties=secured_parties_schema, debtors=debtors_schema,
             vehicleCollateral=vehicle_collateral_schema, generalCollateral=general_collateral_schema
         )

--- a/ppr-api/src/utils/datetime.py
+++ b/ppr-api/src/utils/datetime.py
@@ -7,6 +7,13 @@ import pytz
 PACIFIC_TZ = pytz.timezone('America/Vancouver')
 
 
+def to_date_pacific(d: datetime):
+    # if the date passed in is naive, localize it to UTC, then convert it to pacific to get the correct date
+    aware = pytz.utc.localize(d) if d.tzinfo is None else d
+    pacific_datetime = aware.astimezone(PACIFIC_TZ)
+    return pacific_datetime.date()
+
+
 def today_pacific():
     now_pacific = datetime.datetime.fromtimestamp(time.time(), PACIFIC_TZ)
     return now_pacific.date()

--- a/ppr-api/tests/unit/endpoints/test_financing_statement.py
+++ b/ppr-api/tests/unit/endpoints/test_financing_statement.py
@@ -199,9 +199,13 @@ def test_read_financing_statement_vehicle_collateral_should_be_included():
     assert next(x for x in result.vehicleCollateral if x.manufacturedHomeRegNumber == '5678943')
 
 
-def stub_financing_statement(base_reg_number: str, years: int = -1, parties: list = None, general_collateral=[],
+def stub_financing_statement(base_reg_number: str, years: int = None, parties: list = None, general_collateral=[],
                              vehicle_collateral=[], reg_type: RegistrationType = RegistrationType.SECURITY_AGREEMENT):
-    expiry = datetime.date.today() + datedelta.datedelta(years=years) if years > 0 else None
+    if reg_type == RegistrationType.REPAIRERS_LIEN:
+        expiry = datetime.date.today() + datedelta.datedelta(days=180)
+    else:
+        years = -1 if years is None else years
+        expiry = datetime.date.today() + datedelta.datedelta(years=years) if years > 0 else None
     parties = [models.party.Party(type_code=PartyType.REGISTERING.value, base_registration_number=base_reg_number,
                                   starting_registration_number=base_reg_number, first_name='Fred',
                                   last_name='Flintstone')] if parties is None else parties

--- a/ppr-api/tests/unit/schemas/test_financing_statement_schema.py
+++ b/ppr-api/tests/unit/schemas/test_financing_statement_schema.py
@@ -77,13 +77,38 @@ def test_financing_statement_infinite_life_with_0_years():
         pytest.fail('A validation error was expected since life cannot be true when years are provided')
 
 
-def test_financing_statement_years_infinite_life():
+def test_financing_statement_no_years_infinite_life():
     financing_statement = stub_financing_statement_base(infinite=True)
     assert financing_statement.lifeInfinite is True
 
 
+def test_financing_statement_infinite_life_with_repairers_lien():
+    try:
+        stub_financing_statement_base(infinite=True, reg_type=RegistrationType.REPAIRERS_LIEN.name)
+    except ValueError:
+        pass
+    else:
+        pytest.fail("A validation error was expected since life cannot be provided when it's a Repairer's Lien")
+
+
+def test_financing_statement_years_life_with_repairers_lien():
+    try:
+        stub_financing_statement_base(years=5, reg_type=RegistrationType.REPAIRERS_LIEN.name)
+    except ValueError:
+        pass
+    else:
+        pytest.fail("A validation error was expected since life cannot be provided when it's a Repairer's Lien")
+
+
+def test_financing_statement_no_life_with_repairers_lien():
+    financing_statement = stub_financing_statement_base(years=None, infinite=None,
+                                                        reg_type=RegistrationType.REPAIRERS_LIEN.name)
+    assert financing_statement.lifeInfinite is None
+    assert financing_statement.lifeYears is None
+
+
 def stub_financing_statement_base(
-        years=None, infinite: bool = None, reg_type: str = RegistrationType.SECURITY_AGREEMENT.name,
+        years: int = None, infinite: bool = None, reg_type: str = RegistrationType.SECURITY_AGREEMENT.name,
         secured_parties: list = [], debtors: list = [], vehicle_collateral: list = [], general_collateral: list = []):
     return schemas.financing_statement.FinancingStatementBase(
         lifeYears=years, lifeInfinite=infinite, type=reg_type, securedParties=secured_parties, debtors=debtors,

--- a/ppr-api/tests/unit/utils/test_datetime.py
+++ b/ppr-api/tests/unit/utils/test_datetime.py
@@ -1,6 +1,7 @@
 import datetime
 
 import freezegun
+import pytz
 
 import utils.datetime
 
@@ -27,3 +28,33 @@ def test_today_pacific_early_pst_should_remain_the_same():
 def test_today_pacific_late_pst_should_remain_the_same():
     today = utils.datetime.today_pacific()
     assert today == datetime.date(2020, 2, 22)
+
+
+def test_to_date_pacific_early_utc_should_resolve_to_pacific_date():
+    date_in = datetime.datetime(2020, 2, 22, 0, 0, 1, tzinfo=pytz.utc)
+    actual = utils.datetime.to_date_pacific(date_in)
+    assert actual == datetime.date(2020, 2, 21)
+
+
+def test_to_date_pacific_late_utc_should_remain_the_same():
+    date_in = datetime.datetime(2020, 2, 22, 23, 59, 59, tzinfo=pytz.utc)
+    actual = utils.datetime.to_date_pacific(date_in)
+    assert actual == datetime.date(2020, 2, 22)
+
+
+def test_to_date_pacific_early_pst_should_remain_the_same():
+    date_in = datetime.datetime(2020, 2, 22, 0, 0, 1, tzinfo=utils.datetime.PACIFIC_TZ)
+    actual = utils.datetime.to_date_pacific(date_in)
+    assert actual == datetime.date(2020, 2, 22)
+
+
+def test_to_date_pacific_late_pst_should_remain_the_same():
+    date_in = datetime.datetime(2020, 2, 22, 23, 59, 59, tzinfo=utils.datetime.PACIFIC_TZ)
+    actual = utils.datetime.to_date_pacific(date_in)
+    assert actual == datetime.date(2020, 2, 22)
+
+
+def test_to_date_pacific_early_naive_date_should_behave_as_utc():
+    date_in = datetime.datetime(2020, 2, 22, 6, 0, 1)
+    actual = utils.datetime.to_date_pacific(date_in)
+    assert actual == datetime.date(2020, 2, 21)


### PR DESCRIPTION
Update the API for values that are specific to Repairer's Liens and Security Agreements: trust indenture, lien amount and surrender date

This includes documentation API contract updates