### PR TITLE
Cleanup from duplicate test descriptions

### DIFF
--- a/ppr-ui/tests/unit/base-party/BaseParty.spec.ts
+++ b/ppr-ui/tests/unit/base-party/BaseParty.spec.ts
@@ -36,7 +36,7 @@ describe('BaseParty.vue', (): void => {
       expect(wrapper.findAll('input').exists()).toBeFalsy()
     })
 
-    it(':editing - reactivity test', async (): Promise<void> => {
+    it(':editing - reactivity test for inputs', async (): Promise<void> => {
       const properties = ref<{ editing: boolean; value: BasePartyModel }>({
         editing: false,
         value: new BasePartyModel()

--- a/ppr-ui/tests/unit/financing-statement/SerialCollateral.spec.ts
+++ b/ppr-ui/tests/unit/financing-statement/SerialCollateral.spec.ts
@@ -725,18 +725,6 @@ describe('SerialCollateral.vue', (): void => {
       expect(emittedSerialCollateral.year).toBe(expected)
     })
 
-    it('@input - year change should be emitted', async (): Promise<void> => {
-      const expected = '2013'
-      const properties = ref({ editing: true, value: new SerialCollateralModel() })
-      const wrapper: Wrapper<Vue> = mount(SerialCollateral, { propsData: properties.value, vuetify })
-
-      wrapper.get('[data-test-id="SerialCollateral.input.year"]').setValue(expected)
-      await Vue.nextTick()
-
-      const emittedSerialCollateral = wrapper.emitted('input').slice(-1)[0][0]
-      expect(emittedSerialCollateral.year).toBe(expected)
-    })
-
     // "valid" event.
 
     it('@valid - all motor vehicle fields to emit true', async (): Promise<void> => {

--- a/ppr-ui/tests/unit/load-indicator/load.indicator.spec.ts
+++ b/ppr-ui/tests/unit/load-indicator/load.indicator.spec.ts
@@ -24,6 +24,4 @@ describe('load-indicator.ts', (): void => {
     loadIndicator.stop()
     expect(loadIndicator.isLoading() === false)
   })
-
 })
-

--- a/ppr-ui/tests/unit/views/FinancingStatementView.spec.ts
+++ b/ppr-ui/tests/unit/views/FinancingStatementView.spec.ts
@@ -43,7 +43,7 @@ describe('FinancingStatementView.vue', (): void => {
       })
     })
 
-    it('Test the financing view', async (): Promise<void> => {
+    it('Test the financing view submitted text', async (): Promise<void> => {
       // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
       await new Promise((r) => setTimeout(r, 2000))
       expect(wrapper.get('#financingStatement').text()).toContain('submitted financing statement')
@@ -75,7 +75,7 @@ describe('FinancingStatementView.vue', (): void => {
       })
     })
 
-    it('Test the financing view', async (): Promise<void> => {
+    it('Test the financing view created text', async (): Promise<void> => {
       // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
       await new Promise((r) => setTimeout(r, 2000))
       expect(wrapper.get('#financingStatement').text()).toContain('create a financing statement')


### PR DESCRIPTION
The Jest test extension doesn't like it when the `it('XXX'...` has duplicate values of XXX. Made the values unique where needed, but also deleted an actual duplicate test.

Some minor formatting for consistency.