### PR TITLE
Fixed bug where undefined used in JSON

### DIFF
--- a/ppr-ui/src/base-party/base-party-model.ts
+++ b/ppr-ui/src/base-party/base-party-model.ts
@@ -11,7 +11,7 @@ export interface BasePartyInterface {
 }
 
 /**
- * The model for a that may be a person or a business, such as for a registering party.
+ * The model for a party that may be a person or a business, such as for a registering party.
  */
 export class BasePartyModel {
   private _businessName?: BusinessNameModel

--- a/ppr-ui/src/components/person-name-model.ts
+++ b/ppr-ui/src/components/person-name-model.ts
@@ -53,11 +53,21 @@ export class PersonNameModel {
    * Gets the JSON representation of the PersonNameModel object.
    */
   public toJson(): PersonNameInterface {
-    return {
-      first: this.first,
-      middle: this.middle,
-      last: this.last
+    let rval: PersonNameInterface = {}
+
+    if (this.first) {
+      rval = Object.assign(rval, { first: this.first })
     }
+
+    if (this.middle) {
+      rval = Object.assign(rval, { middle: this.middle })
+    }
+
+    if (this.last) {
+      rval = Object.assign(rval, { last: this.last })
+    }
+
+    return rval
   }
 
   /*

--- a/ppr-ui/tests/unit/components/person-name-model.spec.ts
+++ b/ppr-ui/tests/unit/components/person-name-model.spec.ts
@@ -78,6 +78,9 @@ describe('person-name-model.ts', (): void => {
     const json = {}
     const person = new PersonNameModel()
 
+    expect(json).not.toHaveProperty('first')
+    expect(json).not.toHaveProperty('middle')
+    expect(json).not.toHaveProperty('last')
     expect(person.toJson()).toEqual(json)
     expect(PersonNameModel.fromJson(json)).toEqual(person)
   })
@@ -86,6 +89,9 @@ describe('person-name-model.ts', (): void => {
     const json = { first: 'First', middle: 'Middle', last: 'Last' }
     const person = new PersonNameModel('First', 'Middle', 'Last')
 
+    expect(json).toHaveProperty('first')
+    expect(json).toHaveProperty('middle')
+    expect(json).toHaveProperty('last')
     expect(person.toJson()).toEqual(json)
     expect(PersonNameModel.fromJson(json)).toEqual(person)
   })


### PR DESCRIPTION
The TypeScript value `undefined` was erroneously being used in JSON. Fixed this for the person name, as it was very visible for missing middle names. It likely needs to be done elsewhere, TBD.